### PR TITLE
docs: improve CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,122 +5,118 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-pnpm tauri dev        # Development (starts Vite + Tauri dev window)
+pnpm tauri dev        # Development (Vite + Tauri desktop window)
 pnpm tauri build      # Production build
-pnpm lint / lint:fix  # Lint
-pnpm format           # Format (Prettier sorts Tailwind classes)
-pnpm format:rust      # Format Rust (rustfmt via src-tauri/Cargo.toml)
-pnpm check            # Lint + format together
-pnpm test             # Vitest (single run; see docs/TESTING_STRATEGY.md)
+pnpm lint / lint:fix  # ESLint
+pnpm format           # Prettier (sorts Tailwind classes)
+pnpm format:rust      # cargo fmt
+pnpm check            # lint + format together
+pnpm test             # Vitest single run
 pnpm test:watch       # Vitest watch mode
 pnpm db:generate      # Generate migration after editing src/services/db/schema.ts
 ```
 
-Automated tests use Vitest + Testing Library (`pnpm test`). Strategy and mocking notes: `docs/TESTING_STRATEGY.md`.
+Run a single test file: `pnpm test src/path/to/file.test.tsx`
 
 ## Architecture
 
-**Tauri 2.0** desktop app — Rust backend (`src-tauri/src/lib.rs`) + React 19/TypeScript frontend (`src/`).
+**Tauri 2.0** desktop app — Rust backend (`src-tauri/src/`) + React 19/TypeScript frontend (`src/`).
 
-### Core data flow
+### Hotkey pipeline
 
-Hotkey **Cmd+Ctrl+R** triggers the pipeline:
+Main Raypaste hotkey, (default: **Cmd+Ctrl+R**) triggers:
 
-1. **Hotkey intercept** (Rust): `lib.rs` intercepts via `tauri_plugin_global_shortcut`, calls `commands::focused_app` + `commands::text` on the main thread, then resolves the active tab URL off-thread via `commands::browser_url::try_get_active_tab_url` (AppleScript / `osascript` for supported browsers). Emits `raypaste://hotkey-triggered` with `{ app, selected_text, target_pid, page_url? }`.
+1. **Rust** (`lib.rs`): intercepts via `tauri_plugin_global_shortcut`, captures focused app + selected text on main thread, resolves browser URL off-thread via AppleScript (`commands/browser_url.rs`). Emits `raypaste://hotkey-triggered` with `{ app, selected_text, target_pid, page_url? }`.
+2. **Frontend** (`src/hooks/useAICompletionListener.ts`): resolves prompt, creates `AbortController`, branches to review or instant mode.
+3. **Persistence**: saves to SQLite, emits `raypaste://completion-saved` to refresh `HistoryPage`.
 
-2. **Completion flow** (`src/hooks/useAICompletionListener.ts`):
-   - Resolves active prompt via `resolvePromptForHotkey` in `promptsStore`: when `page_url` is present, **Website prompts** (`websitePromptSites`) are matched first (`pickWebsitePromptMatch` — domain + subdomain match, longest domain wins; then `path-prefix` rules by longest prefix, else a per-site `site` rule). Otherwise: per-app assignment → **Default prompt** (`defaultPromptId`) → built-in `formal` → first prompt in the list. Configure sites under **Website prompts** in the sidebar (`src/pages/website-prompts/WebsitePromptsPage.tsx`). If the user has website prompts but the hotkey fires in a known browser without a `page_url`, an info toast (once per browser bundle ID) notes that the fallback chain was used.
-   - Creates `AbortController` for cancellation support
-   - Branches to **review mode** or **instant mode**:
-     - **Review mode**: Opens review overlay in loading state → streams completion chunks via `raypaste://stream-chunk` → emits `raypaste://stream-done` when complete → ReviewPage transitions to edit state
-     - **Instant mode**: Opens progress overlay → streams completion → writes text back via `invoke("write_text_back")` → closes progress overlay directly via `progressWin.close()`
+**Prompt resolution order** (in `resolvePromptForHotkey`):
 
-3. **Cancellation**: User presses Esc → overlay emits `raypaste://[stream|instant]-cancel` → main window aborts controller → in-flight stream throws `AbortError` → window closes gracefully
+1. Website match (if `page_url` present) — longest domain wins, then longest path-prefix
+2. Per-app assignment
+3. Default prompt (`defaultPromptId`)
+4. Built-in `formal` prompt
+5. First prompt in list
 
-4. **Persistence**: Completion saved to SQLite; `raypaste://completion-saved` emitted to refresh `HistoryPage`.
+If website prompts exist but no `page_url` is available (Firefox unsupported; AppleScript failure), a one-time info toast per browser bundle ID fires.
 
-### Overlay system
+### Multi-window / overlay system
 
-`src/main.tsx` → `<RenderWindow />` routes on `?overlay` query param:
+`src/main.tsx` → `<RenderWindow />` routes on `?overlay` query param. All overlays share the same React bundle — each is a separate `WebviewWindow`:
 
-- _(none)_ → `<App />` (main window)
-- `?overlay=review` → `<ReviewPage />` (streaming text, editable, accept/reject)
-- `?overlay=progress` → `<ProgressPage />` (instant mode: centered spinner + Esc-to-cancel)
-- `?overlay=toast` → `<NotificationPage />` (error/success toast)
+| `?overlay=` | Component              | Purpose                               |
+| ----------- | ---------------------- | ------------------------------------- |
+| _(none)_    | `<App />`              | Main window                           |
+| `review`    | `<ReviewPage />`       | Streaming text editor (accept/reject) |
+| `progress`  | `<ProgressPage />`     | Instant mode spinner                  |
+| `toast`     | `<NotificationPage />` | Error/success toast                   |
 
-**Overlay creation** (`src/services/overlayWindows.ts`):
+**Cross-window IPC:** Overlays share localStorage (same origin). For review mode, initial state + streaming chunks are written to `localStorage[REVIEW_STORAGE_KEY]` — this avoids focus-flashing race conditions with Tauri event delivery timing. Instant mode skips this; main window closes `progressWin.close()` directly.
 
-- `showReviewOverlay()` — creates 600×700 centered window for review mode
-- `showProgressOverlay()` — creates 280×50 centered window for instant mode loading
-- `showToastOverlay()` — creates small notification at bottom-right
-
-**Data passing:**
-
-- **Review mode**: Initial loading state written to `localStorage[REVIEW_STORAGE_KEY]` before window opens. Main window streams chunks via `raypaste://stream-chunk` events. Final state committed via `raypaste://stream-done`.
-- **Instant mode**: Main window directly closes the progress overlay via `progressWin.close()` when done (no cross-window events needed).
-
-**Window lifecycle:** Main window holds the `WebviewWindow` handle and is responsible for cleanup. Overlays can emit cancel events (`raypaste://stream-cancel`, `raypaste://instant-cancel`) to trigger abort.
-
-**Tauri capabilities** (`src-tauri/capabilities/`):
-
-- `default.json` — main window permissions including `core:window:allow-close` (to close overlays)
-- `overlay.json` — `notification-*` and `progress-*` windows with `core:window:allow-close` + `core:event:allow-emit`
-- `review.json` — `review-*` windows with event emission and dragging
+Capability files in `src-tauri/capabilities/` control what each window type can do (emit events, drag, close).
 
 ### State management
 
 Zustand + `persist` (localStorage), all re-exported from `src/stores/index.ts`:
 
-- `settingsStore` — LLM mode (`"direct"` | `"api"`), provider (`"openrouter"` | `"cerebras"`), API keys, model, `reviewMode`, `themeMode` (`"light"` | `"dark"` | `"auto"`)
-- `promptsStore` — CRUD; each prompt has `appIds[]`. App assignments are **exclusive** — `assignAppToPrompt` removes the app from all other prompts. **Website prompts** (`websitePromptSites`): per-site domain plus rules (`path-prefix` for specific URLs on that host, or `site` for the whole domain/subdomain tree). Each prompt also has **denormalized** `websitePromptSiteIds[]` (derived from rules; recomputed in `recomputePromptWebsiteSiteIds` whenever sites/rules change and in `persist` merge — do not add site mutations without keeping this in sync; see `docs/WEBSITE_PROMPTS.md`). Icons for the list UI are loaded through `fetchWebsitePromptSiteIcon` (see Rust `website_icons` below).
+- **`settingsStore`** — LLM mode/provider/keys, `reviewMode`, `themeMode`
+- **`promptsStore`** — prompts CRUD, app assignments, website prompt rules
+- **`appsStore`** — macOS installed apps (not persisted; loaded fresh on each Layout mount)
 
-**Browser URL for website prompts (macOS):** Implemented in `commands/browser_url.rs`. Uses AppleScript for Chrome (incl. Canary), Brave, Edge, Opera, Safari, and Arc. **Automation** permission may be required (System Settings → Privacy & Security → Automation). **Firefox** is not supported (no reliable URL via scripting). If URL lookup fails, resolution skips website matching and uses the per-app / default / built-in fallback chain only.
+**Critical invariants in `promptsStore`:**
 
-- `appsStore` — macOS installed apps list (via `commands::apps::list_apps`)
+- **App assignment is exclusive**: `assignAppToPrompt` removes the app from all other prompts simultaneously (enforced at state level, not just UI).
+- **`websitePromptSiteIds[]` is denormalized** on each `Prompt` (derived from `websitePromptSites` rules). Call `recomputePromptWebsiteSiteIds()` after every mutation that touches sites or rules — including in `persist` merge. Failing to do so breaks the sidebar "Unassigned" count and related UI.
 
 ### LLM service layer
 
-`src/services/llm/index.ts` exports `getLLMClient()` / `getApiKey()` (read `settingsStore` at call time):
+`src/services/llm/index.ts` — `getLLMClient()` factory (reads `settingsStore` at call time):
 
-- `VITE_DRY_RUN=true` → `dryRunClient` (takes priority over all other settings; `getApiKey()` returns `"dry-run"`)
-- `mode: "api"` → `raypasteApiClient` (hosted, coming soon — throws on any call)
-- `mode: "direct"` + `provider: "cerebras"` → `cerebrasClient`
-- `mode: "direct"` + `provider: "openrouter"` → `openrouterClient`
+- `VITE_DRY_RUN=true` → `dryRunClient` (highest priority; used by Vitest via `vitest.config.ts`)
+- `mode: "api"` → `raypasteApiClient` (throws — not yet implemented)
+- `mode: "direct"` → `cerebrasClient` or `openrouterClient`
 
-**Streaming & Cancellation** (`src/services/llm/*.ts`):
+All clients implement `.stream(req, apiKey, onChunk, signal)` with `AbortSignal` support.
 
-- Both clients implement `.stream(req, apiKey, onChunk, signal)` for real-time token delivery
-- `signal: AbortSignal` passed from main window's `AbortController`
-- OpenRouter/Cerebras: SSE stream parsing with abort support (fetch signal interrupts connection)
-- Dry run: simulates streaming with abort checking between word delays
-- Usage data not available during streaming (null placeholder); full stats captured in completion record
+### Database
 
-### Database (SQLite via `tauri-plugin-sql`)
+Schema: `src/services/db/schema.ts`. Migrations: `src/services/db/migrations/*.sql`.
 
-Schema: `src/services/db/schema.ts`. `src/services/db/index.ts` exports:
-`listCompletions`, `saveCompletion`, `updateCompletionOutcome`, `getUsageStats`, `deleteCompletion`, `clearAllCompletions`.
+**Schema changes:** edit schema → `pnpm db:generate` → commit the generated `.sql`. Migrations apply automatically at startup via `PRAGMA user_version`. Never manually edit generated migration files.
 
-**Schema changes:** edit schema → `pnpm db:generate` → commit the new `.sql` in `src/services/db/migrations/`. Migrations run automatically at startup via `PRAGMA user_version`. Never edit generated migration files.
+### Rust backend
 
-### Rust commands
+New commands go under `src-tauri/src/commands/` and are registered in `lib.rs`. Keep command handlers thin — parse inputs, delegate to helpers, return `Result<T, String>`.
 
-`src-tauri/src/commands/` — modules:
+**AppKit/AX APIs must run on the main thread** — use `run_on_main_thread`. Do not call UI or Accessibility APIs from spawned threads.
 
-- `apps::list_apps` / `get_icon_base64` / `get_icon_base64_for_icns`
-- `browser_url::try_get_active_tab_url` — optional active tab URL via `osascript` (feeds `page_url` for website prompt matching)
-- `website_icons::fetch_website_icon` — fetches and normalizes a site favicon (HTTP fetch, HTML `<link rel>` discovery, image bytes → data URL). The frontend only calls this via `invoke` from `src/services/websiteIcons.ts`; orchestration and caching of results per site live in `promptsStore.fetchWebsitePromptSiteIcon` + `WebsitePromptsPage`.
-- `focused_app::get_focused_app` / `get_frontmost_pid` — NSWorkspace/NSRunningApplication (ObjC2) bundle ID + PID
-- `focused_app::activate_app` — re-activates a target app by PID (used in instant mode to return focus)
-- `text::get_selected_text` / `write_text_back` — AX read/write
+Return `Result<T, String>` (or serializable error) from `#[tauri::command]`; propagate errors with `?`. Avoid `unwrap()`/`expect()` on user-facing paths.
 
-All AppKit/AX calls must run on the main thread (`run_on_main_thread`).
-
-**App icons:** `.icns` → PNG conversion + caching pipeline — see `docs/APP_ICONS.md`. (Separate from **website** favicons in `website_icons.rs`.)
+Run `cargo clippy` before large Rust changes; fix new warnings when reasonable.
 
 ### Frontend conventions
 
-- Path alias: `#` → `./src` (use `#/components/...`, `#/services/...`, etc.)
+- Path alias: `#` → `./src`
 - Navigation: pure React state in `Layout.tsx` — no router library
-- Pages in `src/pages/`, UI primitives in `src/components/ui/` (Radix UI wrappers)
-- Tailwind CSS v4; dark-themed, transparent overlay-titlebar window (1200×800, min 900×600)
-- `__APP_VERSION__` global injected from `package.json`; Vite dev server on port 1420
+- UI primitives: `src/components/ui/` (Radix UI wrappers)
+- Tailwind CSS v4; dark-themed by default
+
+### Testing
+
+`vitest.config.ts` sets `VITE_DRY_RUN=true` so LLM paths work without real API calls.
+
+**Mocking pattern** — use hoisted `Map` for Tauri event listeners:
+
+```typescript
+const listeners = vi.hoisted(() => new Map<string, Handler>());
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (event, handler) => {
+    listeners.set(event, handler);
+    return Promise.resolve(() => {});
+  },
+  emit: vi.fn(),
+}));
+// In test: listeners.get("raypaste://hotkey-triggered")!({ payload: {...} });
+```
+
+Mock helpers: `src/test/mocks/tauri.ts`. DB is mocked via `vi.mock("#/services/db")`. See `docs/TESTING_STRATEGY.md` for coverage priorities.


### PR DESCRIPTION
## Background

This PR refactors and streamlines the `CLAUDE.md` documentation to improve scannability and remove redundant information that is easily discoverable within the codebase. It updates the architectural overview to reflect current multi-window logic and clarifies critical state invariants.

## Changes

**Documentation Cleanup**
* Condensed verbose command descriptions and merged Rust backend guidance from external rules into the main guide.
* Removed explicit window dimensions, file-by-file capability breakdowns, and internal caching details that are discoverable in the source or specific documentation files.
* Replaced prose-heavy sections with a structured table for the overlay system (Review, Progress, Toast).

**Architecture & Logic Clarification**
* Added explicit documentation for the single-test command: `pnpm test <file>`.
* Documented the `localStorage` cross-window IPC rationale used to avoid focus-flashing race conditions during Tauri event delivery.
* Formalized the prompt resolution fallback chain (Website -> App -> Default -> Built-in) and identified the Firefox AppleScript limitation.
* Highlighted critical `promptsStore` invariants, specifically the exclusive nature of app assignments and the necessity of recomputing denormalized website site IDs.

**Development & Tooling**
* Added `cargo clippy` guidance for Rust contributions.
* Documented the specific Vitest mocking pattern using hoisted `Map` objects for Tauri event listeners.
* Simplified path alias and frontend convention notes.

## Testing

* Updated `CLAUDE.md` to reflect that `VITE_DRY_RUN=true` is the default state for Vitest to ensure LLM paths function without API keys during local test execution.