### PR TITLE
style(UI): mix brand green into neutral grey theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -149,7 +149,7 @@ body,
   --chart-3: #5fb884;
   --chart-4: #a8e0c0;
   --chart-5: #c4ebce;
-  --sidebar: var(--neutral-950);
+  --sidebar: var(--neutral-900);
   --sidebar-foreground: var(--text-primary);
   --sidebar-primary: var(--brand);
   --sidebar-primary-foreground: var(--neutral-950);

--- a/src/App.css
+++ b/src/App.css
@@ -102,15 +102,15 @@ body,
    * Dark surfaces stay nearly neutral charcoal; brand is a trace.
    * Light end of scale = text (barely off-white + hint of green).
    */
-  --neutral-950: color-mix(in srgb, #0a0a0a 96.5%, var(--brand) 3.5%);
-  --neutral-900: color-mix(in srgb, #141414 96%, var(--brand) 4%);
-  --neutral-800: color-mix(in srgb, #1f1f1f 95%, var(--brand) 5%);
-  --neutral-700: color-mix(in srgb, #2a2a2a 94.5%, var(--brand) 5.5%);
-  --neutral-600: color-mix(in srgb, #3f3f3f 94%, var(--brand) 6%);
-  --neutral-500: color-mix(in srgb, #525252 93.5%, var(--brand) 6.5%);
-  --neutral-400: color-mix(in srgb, #737373 93%, var(--brand) 7%);
-  --neutral-300: color-mix(in srgb, #a3a3a3 92%, var(--brand) 8%);
-  --neutral-200: color-mix(in srgb, #d4d4d4 91%, var(--brand) 9%);
+  --neutral-950: color-mix(in srgb, #0a0a0a 97%, var(--brand) 3%);
+  --neutral-900: color-mix(in srgb, #141414 97%, var(--brand) 3%);
+  --neutral-800: color-mix(in srgb, #1f1f1f 96%, var(--brand) 4%);
+  --neutral-700: color-mix(in srgb, #2a2a2a 95%, var(--brand) 5%);
+  --neutral-600: color-mix(in srgb, #3f3f3f 95%, var(--brand) 5%);
+  --neutral-500: color-mix(in srgb, #525252 94%, var(--brand) 6%);
+  --neutral-400: color-mix(in srgb, #737373 94%, var(--brand) 6%);
+  --neutral-300: color-mix(in srgb, #a3a3a3 93%, var(--brand) 7%);
+  --neutral-200: color-mix(in srgb, #d4d4d4 92%, var(--brand) 8%);
   --neutral-100: color-mix(in srgb, #eceeec 97%, var(--brand) 3%);
   --neutral-50: color-mix(in srgb, #f6f8f7 98%, var(--brand) 2%);
 

--- a/src/App.css
+++ b/src/App.css
@@ -24,78 +24,169 @@ body,
 }
 
 :root {
-  --background: #f8f8f8;
-  --foreground: #0a0a0a;
-  --card: #ffffff;
-  --card-foreground: #0a0a0a;
-  --popover: #ffffff;
-  --popover-foreground: #0a0a0a;
-  --primary: #97d8b2;
-  --primary-foreground: #0a0a0a;
-  --secondary: #f5f5f5;
-  --secondary-foreground: #0a0a0a;
-  --muted: #f5f5f5;
-  --muted-foreground: #525252;
-  --accent: #f5f5f5;
-  --accent-foreground: #0a0a0a;
+  /* Brand — single source for tints, shadows, and interactive wash */
+  --brand: #97d8b2;
+  --brand-rgb: 151 216 178;
+
+  /* Tinted neutrals: trace of brand only (cf. bg ~3%, surface ~1.5%, border grey ~5%) */
+  --neutral-50: color-mix(in srgb, #fafafa 97%, var(--brand) 3%);
+  --neutral-100: color-mix(in srgb, #f5f5f5 97%, var(--brand) 3%);
+  --neutral-200: color-mix(in srgb, #e5e5e5 95%, var(--brand) 5%);
+  --neutral-300: color-mix(in srgb, #d4d4d4 94%, var(--brand) 6%);
+  --neutral-400: color-mix(in srgb, #a3a3a3 93%, var(--brand) 7%);
+  --neutral-500: color-mix(in srgb, #737373 97%, var(--brand) 3%);
+  --neutral-600: color-mix(in srgb, #525252 94%, var(--brand) 6%);
+  --neutral-700: color-mix(in srgb, #404040 95%, var(--brand) 5%);
+  --neutral-800: color-mix(in srgb, #262626 96%, var(--brand) 4%);
+  --neutral-900: color-mix(in srgb, #171717 96.5%, var(--brand) 3.5%);
+  --neutral-950: color-mix(in srgb, #0a0a0a 97%, var(--brand) 3%);
+
+  --brand-subtle: color-mix(in srgb, var(--brand) 10%, white);
+  --brand-subtle-foreground: color-mix(
+    in srgb,
+    var(--neutral-950) 96%,
+    var(--brand) 4%
+  );
+
+  /* Near-black / near-white text with same hue temperature as neutrals */
+  --text-primary: var(--neutral-950);
+  --text-secondary: var(--neutral-600);
+  --text-muted: var(--neutral-500);
+
+  /* Shadows: mostly neutral depth, slight warm cast */
+  --shadow-brand: rgb(var(--brand-rgb) / 0.07);
+  --shadow-brand-soft: rgb(var(--brand-rgb) / 0.04);
+  --shadow-brand-line: rgb(var(--brand-rgb) / 0.028);
+
+  --background: var(--neutral-50);
+  --foreground: var(--text-primary);
+  --card: color-mix(in srgb, #ffffff 98.5%, var(--brand) 1.5%);
+  --card-foreground: var(--text-primary);
+  --popover: color-mix(in srgb, #ffffff 98.5%, var(--brand) 1.5%);
+  --popover-foreground: var(--text-primary);
+  --primary: var(--brand);
+  --primary-foreground: var(--neutral-950);
+  --secondary: var(--neutral-100);
+  --secondary-foreground: var(--text-primary);
+  --muted: var(--neutral-100);
+  --muted-foreground: var(--text-muted);
+  --accent: var(--neutral-100);
+  --accent-foreground: var(--text-primary);
   --destructive: #dc2626;
   --destructive-strong: #991b1b;
-  --border: #e5e5e5;
-  --input: #e5e5e5;
-  --ring: #97d8b2;
+  --border: var(--neutral-200);
+  --input: var(--neutral-200);
+  --ring: var(--brand);
   --chart-1: #97d8b2;
   --chart-2: #7bc99a;
   --chart-3: #5fb884;
   --chart-4: #a8e0c0;
   --chart-5: #c4ebce;
   --radius: 0.625rem;
-  --sidebar: #fafafa;
-  --sidebar-foreground: #0a0a0a;
-  --sidebar-primary: #97d8b2;
-  --sidebar-primary-foreground: #0a0a0a;
-  --sidebar-accent: #f5f5f5;
-  --sidebar-accent-foreground: #0a0a0a;
-  --sidebar-border: #e5e5e5;
-  --sidebar-ring: #97d8b2;
+  --sidebar: var(--neutral-50);
+  --sidebar-foreground: var(--text-primary);
+  --sidebar-primary: var(--brand);
+  --sidebar-primary-foreground: var(--neutral-950);
+  --sidebar-accent: var(--neutral-100);
+  --sidebar-accent-foreground: var(--text-primary);
+  --sidebar-border: var(--neutral-200);
+  --sidebar-ring: var(--brand);
 }
 
 .dark {
-  --background: #0a0a0a;
-  --foreground: #f5f5f5;
-  --card: #141414;
-  --card-foreground: #f5f5f5;
-  --popover: #141414;
-  --popover-foreground: #f5f5f5;
-  --primary: #97d8b2;
-  --primary-foreground: #0a0a0a;
-  --secondary: #1e1e1e;
-  --secondary-foreground: #f5f5f5;
-  --muted: #1e1e1e;
-  --muted-foreground: #a0a0a0;
-  --accent: #1e1e1e;
-  --accent-foreground: #f5f5f5;
+  --shadow-brand: rgb(var(--brand-rgb) / 0.1);
+  --shadow-brand-soft: rgb(var(--brand-rgb) / 0.055);
+  --shadow-brand-line: rgb(var(--brand-rgb) / 0.035);
+
+  /*
+   * Dark surfaces stay nearly neutral charcoal; brand is a trace.
+   * Light end of scale = text (barely off-white + hint of green).
+   */
+  --neutral-950: color-mix(in srgb, #0a0a0a 96.5%, var(--brand) 3.5%);
+  --neutral-900: color-mix(in srgb, #141414 96%, var(--brand) 4%);
+  --neutral-800: color-mix(in srgb, #1f1f1f 95%, var(--brand) 5%);
+  --neutral-700: color-mix(in srgb, #2a2a2a 94.5%, var(--brand) 5.5%);
+  --neutral-600: color-mix(in srgb, #3f3f3f 94%, var(--brand) 6%);
+  --neutral-500: color-mix(in srgb, #525252 93.5%, var(--brand) 6.5%);
+  --neutral-400: color-mix(in srgb, #737373 93%, var(--brand) 7%);
+  --neutral-300: color-mix(in srgb, #a3a3a3 92%, var(--brand) 8%);
+  --neutral-200: color-mix(in srgb, #d4d4d4 91%, var(--brand) 9%);
+  --neutral-100: color-mix(in srgb, #eceeec 97%, var(--brand) 3%);
+  --neutral-50: color-mix(in srgb, #f6f8f7 98%, var(--brand) 2%);
+
+  --brand-subtle: color-mix(in srgb, var(--neutral-800) 94%, var(--brand) 6%);
+  --brand-subtle-foreground: color-mix(
+    in srgb,
+    var(--neutral-50) 97%,
+    var(--brand) 3%
+  );
+
+  --text-primary: var(--neutral-50);
+  --text-secondary: var(--neutral-300);
+  --text-muted: var(--neutral-300);
+
+  --background: var(--neutral-950);
+  --foreground: var(--text-primary);
+  --card: var(--neutral-900);
+  --card-foreground: var(--text-primary);
+  --popover: var(--neutral-900);
+  --popover-foreground: var(--text-primary);
+  --primary: var(--brand);
+  --primary-foreground: var(--neutral-950);
+  --secondary: var(--neutral-800);
+  --secondary-foreground: var(--text-primary);
+  --muted: var(--neutral-800);
+  --muted-foreground: var(--text-muted);
+  --accent: var(--neutral-800);
+  --accent-foreground: var(--text-primary);
   --destructive: #ff6b6b;
   --destructive-strong: #fecaca;
-  --border: #2a2a2a;
-  --input: #2a2a2a;
-  --ring: #97d8b2;
+  --border: var(--neutral-800);
+  --input: var(--neutral-800);
+  --ring: var(--brand);
   --chart-1: #97d8b2;
   --chart-2: #7bc99a;
   --chart-3: #5fb884;
   --chart-4: #a8e0c0;
   --chart-5: #c4ebce;
-  --sidebar: #121212;
-  --sidebar-foreground: #f5f5f5;
-  --sidebar-primary: #97d8b2;
-  --sidebar-primary-foreground: #0a0a0a;
-  --sidebar-accent: #1e1e1e;
-  --sidebar-accent-foreground: #f5f5f5;
-  --sidebar-border: #2a2a2a;
-  --sidebar-ring: #97d8b2;
+  --sidebar: var(--neutral-950);
+  --sidebar-foreground: var(--text-primary);
+  --sidebar-primary: var(--brand);
+  --sidebar-primary-foreground: var(--neutral-950);
+  --sidebar-accent: var(--neutral-800);
+  --sidebar-accent-foreground: var(--text-primary);
+  --sidebar-border: var(--neutral-800);
+  --sidebar-ring: var(--brand);
 }
 
 @theme inline {
   --font-sans: "Geist Variable", sans-serif;
+  --color-neutral-50: var(--neutral-50);
+  --color-neutral-100: var(--neutral-100);
+  --color-neutral-200: var(--neutral-200);
+  --color-neutral-300: var(--neutral-300);
+  --color-neutral-400: var(--neutral-400);
+  --color-neutral-500: var(--neutral-500);
+  --color-neutral-600: var(--neutral-600);
+  --color-neutral-700: var(--neutral-700);
+  --color-neutral-800: var(--neutral-800);
+  --color-neutral-900: var(--neutral-900);
+  --color-neutral-950: var(--neutral-950);
+  --color-brand-subtle: var(--brand-subtle);
+  --color-brand-subtle-foreground: var(--brand-subtle-foreground);
+  --shadow-xs: 0 1px 1px 0 var(--shadow-brand-line);
+  --shadow-sm:
+    0 1px 2px 0 var(--shadow-brand-soft), 0 0 0 1px var(--shadow-brand-line);
+  --shadow-md:
+    0 4px 6px -1px var(--shadow-brand-soft),
+    0 2px 4px -2px var(--shadow-brand-line), 0 0 0 1px var(--shadow-brand-line);
+  --shadow-lg:
+    0 10px 15px -3px var(--shadow-brand-soft),
+    0 4px 6px -4px var(--shadow-brand-line), 0 0 0 1px var(--shadow-brand-line);
+  --shadow-xl:
+    0 20px 25px -5px var(--shadow-brand),
+    0 8px 10px -6px var(--shadow-brand-soft), 0 0 0 1px var(--shadow-brand-line);
+  --shadow-2xl: 0 25px 50px -12px var(--shadow-brand);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/App.css
+++ b/src/App.css
@@ -28,13 +28,13 @@ body,
   --brand: #97d8b2;
   --brand-rgb: 151 216 178;
 
-  /* Tinted neutrals: trace of brand only (cf. bg ~3%, surface ~1.5%, border grey ~5%) */
-  --neutral-50: color-mix(in srgb, #fafafa 97%, var(--brand) 3%);
-  --neutral-100: color-mix(in srgb, #f5f5f5 97%, var(--brand) 3%);
+  /* Tinted neutrals: trace of brand only */
+  --neutral-50: color-mix(in srgb, #fafafa 96%, var(--brand) 4%);
+  --neutral-100: color-mix(in srgb, #f5f5f5 96%, var(--brand) 4%);
   --neutral-200: color-mix(in srgb, #e5e5e5 95%, var(--brand) 5%);
   --neutral-300: color-mix(in srgb, #d4d4d4 94%, var(--brand) 6%);
   --neutral-400: color-mix(in srgb, #a3a3a3 93%, var(--brand) 7%);
-  --neutral-500: color-mix(in srgb, #737373 97%, var(--brand) 3%);
+  --neutral-500: color-mix(in srgb, #737373 96%, var(--brand) 4%);
   --neutral-600: color-mix(in srgb, #525252 94%, var(--brand) 6%);
   --neutral-700: color-mix(in srgb, #404040 95%, var(--brand) 5%);
   --neutral-800: color-mix(in srgb, #262626 96%, var(--brand) 4%);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          "bg-secondary-foreground text-neutral-50 hover:bg-secondary-foreground/80 aria-expanded:bg-secondary-foreground aria-expanded:text-neutral-50",
+          "bg-secondary-foreground text-neutral-50 dark:text-neutral-900 hover:bg-secondary-foreground/80 aria-expanded:bg-secondary-foreground aria-expanded:text-neutral-50",
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -118,7 +118,6 @@ export function SettingsPage() {
                   themeMode === value
                     ? [
                         "bg-background text-foreground hover:bg-background shadow-sm",
-                        // secondary and muted are the same hex in .dark — use input + border so the pill reads clearly
                         "dark:border-border dark:text-foreground dark:hover:text-foreground dark:bg-neutral-900 dark:shadow-xs dark:hover:bg-neutral-900/80",
                       ]
                     : "text-muted-foreground hover:text-foreground",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -119,7 +119,7 @@ export function SettingsPage() {
                     ? [
                         "bg-background text-foreground hover:bg-background shadow-sm",
                         // secondary and muted are the same hex in .dark — use input + border so the pill reads clearly
-                        "dark:border-border dark:bg-input dark:text-foreground dark:hover:bg-input/90 dark:hover:text-foreground dark:shadow-md",
+                        "dark:border-border dark:text-foreground dark:hover:text-foreground dark:bg-neutral-900 dark:shadow-xs dark:hover:bg-neutral-900/80",
                       ]
                     : "text-muted-foreground hover:text-foreground",
                 )}
@@ -390,7 +390,7 @@ export function SettingsPage() {
                         key={app.bundleId}
                         className="bg-muted/20 flex items-center gap-3 rounded-lg border px-3 py-2"
                       >
-                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/70 shadow-sm ring-1 ring-black/5 dark:bg-white/5 dark:ring-white/10">
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/70 shadow-sm ring-1 ring-neutral-900/8 dark:bg-white/5 dark:ring-neutral-200/15">
                           {hiddenAppIcons[app.bundleId] ? (
                             <img
                               src={hiddenAppIcons[app.bundleId]}

--- a/src/pages/apps/AppsPage.tsx
+++ b/src/pages/apps/AppsPage.tsx
@@ -190,7 +190,7 @@ export function AppsPage({ onNavigateToSettings }: AppsPageProps) {
                         ))}
                       </div>
                     ) : (
-                      <p className="text-muted-foreground mt-3 text-sm">
+                      <p className="text-muted-foreground mt-3 text-xs font-light italic">
                         No prompts assigned yet. Add one below for quick access
                         when this app is active.
                       </p>
@@ -217,7 +217,7 @@ export function AppsPage({ onNavigateToSettings }: AppsPageProps) {
                           inputClassName="w-full min-w-0 max-w-none"
                         />
                       </div>
-                      <p className="text-muted-foreground text-xs">
+                      <p className="text-muted-foreground text-xs font-light">
                         {addablePrompts.length > 0
                           ? "Apps can map to multiple prompts."
                           : "No additional prompts available."}

--- a/src/pages/apps/AppsPage.tsx
+++ b/src/pages/apps/AppsPage.tsx
@@ -113,7 +113,7 @@ export function AppsPage({ onNavigateToSettings }: AppsPageProps) {
                   )}
                 >
                   <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-white/70 shadow-sm ring-1 ring-black/5 dark:bg-white/5 dark:ring-white/10">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-white/70 shadow-sm ring-1 ring-neutral-900/8 dark:bg-white/5 dark:ring-neutral-200/15">
                       {iconSrcByBundleId[app.bundleId] ? (
                         <img
                           src={iconSrcByBundleId[app.bundleId]}

--- a/src/pages/history/OverviewPanel.tsx
+++ b/src/pages/history/OverviewPanel.tsx
@@ -25,7 +25,7 @@ function ClearHistoryDialog({ onConfirm }: { onConfirm: () => void }) {
           <Button
             type="button"
             variant="outline"
-            className="border-border bg-muted/20 text-muted-foreground hover:border-border hover:bg-muted/30 hover:text-foreground gap-2 px-4 py-2 text-[12px] font-normal"
+            className="border-border bg-muted/30 text-muted-foreground hover:border-border hover:bg-muted/30 hover:text-foreground gap-2 px-4 py-2 text-[12px] font-normal"
           />
         }
       >
@@ -70,7 +70,7 @@ function ResetAllDialog({ onConfirm }: { onConfirm: () => void }) {
           <Button
             type="button"
             variant="destructive"
-            className="border-destructive/30 bg-destructive/10 text-destructive/70 hover:border-destructive/50 hover:bg-destructive/20 hover:text-destructive w-full gap-2 px-4 py-2 text-[12px] font-normal"
+            className="border-destructive/30 bg-destructive/10 text-destructive/70 hover:border-destructive/50 hover:bg-destructive/20 hover:text-destructive gap-2 px-4 py-2 text-[12px] font-normal"
           />
         }
       >
@@ -196,7 +196,7 @@ export function OverviewPanel({
       )}
 
       {/* Actions */}
-      <section className="mt-auto flex flex-col gap-2 pt-2">
+      <section className="mt-auto flex justify-end gap-2 pt-2">
         <ClearHistoryDialog onConfirm={onClearHistory} />
         <ResetAllDialog onConfirm={onResetAll} />
       </section>

--- a/src/pages/history/StatusIcon.tsx
+++ b/src/pages/history/StatusIcon.tsx
@@ -11,5 +11,5 @@ export function StatusIcon({ row }: { row: CompletionEntry }) {
     return <CheckCircle2 size={13} className="shrink-0 text-emerald-500" />;
   }
 
-  return <XCircle size={13} className="shrink-0 text-orange-400" />;
+  return <XCircle size={13} className="shrink-0 text-red-400" />;
 }

--- a/src/pages/prompts/NewPromptPage.tsx
+++ b/src/pages/prompts/NewPromptPage.tsx
@@ -227,13 +227,13 @@ export function NewPromptPage({ onCreated, prefill }: NewPromptPageProps) {
           onChange={setSelectedAppIds}
         />
 
-        <div className="border-border bg-muted/10 space-y-4 rounded-xl border p-4">
+        <div className="border-border bg-muted/10 space-y-4 rounded-lg border p-3">
           <div className="flex items-start justify-between gap-3">
             <div className="space-y-1">
-              <p className="text-foreground text-sm font-semibold">
+              <p className="text-foreground text-sm font-medium">
                 Website prompt
               </p>
-              <p className="text-muted-foreground text-sm">
+              <p className="text-muted-foreground text-xs">
                 Optionally connect this prompt to a website or page when you
                 save it.
               </p>
@@ -265,7 +265,7 @@ export function NewPromptPage({ onCreated, prefill }: NewPromptPageProps) {
           {websiteEnabled ? (
             <div className="space-y-4">
               <div className="space-y-2">
-                <p className="text-muted-foreground text-xs">
+                <p className="text-muted-foreground text-xs font-medium">
                   When you trigger Raypaste while on the connected website or
                   page, this prompt will be used.
                 </p>

--- a/src/pages/website-prompts/WebsitePromptSiteList.tsx
+++ b/src/pages/website-prompts/WebsitePromptSiteList.tsx
@@ -44,7 +44,7 @@ export function WebsitePromptSiteList({
               "h-auto min-h-0 w-full flex-col items-stretch rounded-xl border p-2 text-left font-normal",
               isSelected
                 ? "border-primary/30 bg-primary/8"
-                : "border-border bg-background/70 hover:bg-background",
+                : "border-border bg-background/70",
             )}
           >
             <div className="flex items-center gap-3">
@@ -59,7 +59,7 @@ export function WebsitePromptSiteList({
                   <p className="text-foreground truncate text-sm font-semibold">
                     {site.domain || "New website"}
                   </p>
-                  <span className="bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 text-[10px] leading-none">
+                  <span className="bg-secondary text-muted-foreground rounded-full px-1.5 py-0.5 text-[10px] leading-none">
                     {site.rules.length}
                   </span>
                 </div>


### PR DESCRIPTION
## Background

This PR introduces design system updates to our application. We've revamped the color palette to better align with our brand identity, making our UI more consistent across different themes.

## Changes

* Updated color palette using a single source for tones, shadows, and interactive wash across light and dark themes.
* Replaced custom hex values with variables, enabling easier customization and updates.
* Removed unused or redundant color values.
* Introduced neutral colors to enhance text contrast and accessibility.
* Added new classes for shadows and borders to improve design consistency.

## Testing
### Before
<img width="1312" height="912" alt="Screenshot 2026-03-30 at 10 47 42 AM" src="https://github.com/user-attachments/assets/56851785-11d1-4b72-82b8-21003e4e0b27" />

### After
<img width="1312" height="912" alt="Screenshot 2026-03-30 at 9 36 00 PM" src="https://github.com/user-attachments/assets/e6308058-c060-4a54-9355-b8d4563844bd" />

