### PR TITLE
fix: hidden apps no longer display in app selection in prompts pages

### DIFF
--- a/src/pages/prompts/PromptAppSelector.test.tsx
+++ b/src/pages/prompts/PromptAppSelector.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PromptAppSelector } from "#/pages/prompts/PromptAppSelector";
+import { useAppsStore } from "#/stores";
+
+vi.mock("#/hooks/useAppIcons", () => ({
+  useAppIcons: () => ({}),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("PromptAppSelector", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppsStore.setState({
+      apps: [
+        { name: "Visible App", bundleId: "com.visible" },
+        { name: "Hidden App", bundleId: "com.hidden" },
+      ],
+      activeApp: null,
+      hiddenAppBundleIds: ["com.hidden"],
+    });
+    vi.spyOn(useAppsStore.persist, "rehydrate").mockResolvedValue(undefined);
+  });
+
+  it("does not offer hidden apps in the picker", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<PromptAppSelector assignedAppIds={[]} onChange={onChange} />);
+
+    const region = screen.getByText(/apps using this prompt/i).closest("div");
+    expect(region).toBeTruthy();
+    const trigger = within(region as HTMLElement).getByRole("button", {
+      name: "",
+    });
+    await user.click(trigger);
+
+    expect(await screen.findByText("Visible App")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden App")).not.toBeInTheDocument();
+  });
+
+  it("still shows chips for assigned apps that are hidden", () => {
+    render(
+      <PromptAppSelector assignedAppIds={["com.hidden"]} onChange={() => {}} />,
+    );
+
+    expect(screen.getByText("Hidden App")).toBeInTheDocument();
+  });
+});

--- a/src/pages/prompts/PromptAppSelector.tsx
+++ b/src/pages/prompts/PromptAppSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
   filterComboboxItems,
@@ -37,7 +37,7 @@ export function PromptAppSelector({
   assignedAppIds,
   onChange,
 }: PromptAppSelectorProps) {
-  const { apps, setApps } = useAppsStore();
+  const { apps, setApps, hiddenAppBundleIds } = useAppsStore();
   const [query, setQuery] = useState("");
   const { searchDirty, onOpenChange, markSearchDirtyFromInput } =
     useComboboxSearchDirty();
@@ -55,17 +55,30 @@ export function PromptAppSelector({
 
   const anchor = useComboboxAnchor();
 
+  const hiddenSet = useMemo(
+    () => new Set(hiddenAppBundleIds),
+    [hiddenAppBundleIds],
+  );
+  const selectableApps = useMemo(
+    () => apps.filter((a) => !hiddenSet.has(a.bundleId)),
+    [apps, hiddenSet],
+  );
+
   // Preserve order to match combobox chip index positions
   const assignedApps = assignedAppIds
     .map((id) => apps.find((a) => a.bundleId === id))
     .filter(Boolean) as InstalledApp[];
 
   const filteredApps = filterComboboxItems(
-    apps,
+    selectableApps,
     query,
     searchDirty,
     (a) => a.name,
   );
+
+  const allSelectableAssigned =
+    selectableApps.length > 0 &&
+    selectableApps.every((a) => assignedAppIds.includes(a.bundleId));
 
   return (
     <div className="space-y-2">
@@ -111,7 +124,7 @@ export function PromptAppSelector({
                 {app.name}
               </ComboboxItem>
             ))}
-            {apps.length === assignedApps.length && (
+            {allSelectableAssigned && (
               <ComboboxEmpty>
                 All available apps have been assigned.
               </ComboboxEmpty>


### PR DESCRIPTION
## Background

This PR updates `PromptAppSelector` component to filter hidden apps.

## Changes

* Added tests for `PromptAppSelector` to verify app filtering and assignment visualization.
* Enhanced the `PromptAppSelector` component to exclude hidden apps in the picker and show chips for assigned hidden apps.
* Updated the `useAppsStore` state to include `hiddenAppBundleIds` and implemented filtering based on this new state.
* Optimized the `PromptAppSelector` component to use `useMemo` to improve performance.

## Testing

### Checked New Prompt page and View/Edit Prompt page to see if hidden apps no longer show up in select inputs

* Verified the `PromptAppSelector` component's filtering and assignment visualization in both tests.
