### PR TITLE
feat: add OpenAI direct to provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For detailed compatibility information and contributor guidance on cross-platfor
 | Frontend      | React 19 + TypeScript                    |
 | Styling       | Tailwind CSS v4                          |
 | State         | Zustand                                  |
-| LLM providers | OpenRouter, Cerebras                     |
+| LLM providers | OpenRouter, Cerebras, OpenAI             |
 
 ## Quick Start
 
@@ -75,14 +75,16 @@ For full setup instructions see the **[getting started guide](docs/DEV_GETTING_S
 
 ## LLM Providers
 
-Raypaste currently supports two **direct-to-provider** modes (your data never touches Raypaste servers):
+Raypaste currently supports three **direct-to-provider** modes (your data never touches Raypaste servers):
 
 - **[OpenRouter](https://openrouter.ai/)** — access to a wide range of models
   - [Models used by Raypaste users](https://openrouter.ai/apps?url=https%3A%2F%2Fraypaste.com%2F) — see what models people are using with Raypaste through OpenRouter
 - **[Cerebras](https://www.cerebras.ai/)** — ultra-fast inference powered by their Wafer Scale Engine
   - [Cerebras Chips](https://www.cerebras.ai/chip) - read more about Cerebras hardware
+- **[OpenAI](https://platform.openai.com/)** — direct access to the GPT-5 and GPT-5.4 families in Raypaste
 
 Configure your API keys in the Raypaste app's Settings page (your API keys are stored on your device and do not pass through Raypaste's servers).
+The Settings page filters models by provider so users only see the models currently provisioned for that direct connection. See **[docs/MODEL_PROVIDER_COMPLIANCE.md](docs/MODEL_PROVIDER_COMPLIANCE.md)** for the current matrix.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Raypaste currently supports three **direct-to-provider** modes (your data never 
 - **[OpenAI](https://platform.openai.com/)** — direct access to the GPT-5 and GPT-5.4 families in Raypaste
 
 Configure your API keys in the Raypaste app's Settings page (your API keys are stored on your device and do not pass through Raypaste's servers).
-The Settings page filters models by provider so users only see the models currently provisioned for that direct connection. See **[docs/MODEL_PROVIDER_COMPLIANCE.md](docs/MODEL_PROVIDER_COMPLIANCE.md)** for the current matrix.
+The Settings page filters models by provider so users only see models allowed for that direct connection. See **[docs/MODEL_PROVIDER_COMPLIANCE.md](docs/MODEL_PROVIDER_COMPLIANCE.md)** for how provider-scoped filtering and normalization work.
 
 ## Contributing
 

--- a/docs/DEV_GETTING_STARTED.md
+++ b/docs/DEV_GETTING_STARTED.md
@@ -41,7 +41,7 @@ You can set one or more of [OpenRouter](https://openrouter.ai/), [Cerebras](http
 
 **(Privacy-first):** Your prompt, inputs, and outputs do not pass through Raypaste's servers and are not stored anywhere in our database. Your request goes from the app to the provider you selected and returns directly back to you. Please review each provider's privacy policies on how they will interact with your personal/business data.
 
-Raypaste filters the model picker by provider so only the models currently provisioned and validated for that direct connection are shown. See [MODEL_PROVIDER_COMPLIANCE.md](MODEL_PROVIDER_COMPLIANCE.md) for the current matrix.
+Raypaste filters the model picker by provider so only models allowed for that direct connection are shown. See [MODEL_PROVIDER_COMPLIANCE.md](MODEL_PROVIDER_COMPLIANCE.md) for the filtering and normalization rules.
 
 ### Raypaste API
 

--- a/docs/DEV_GETTING_STARTED.md
+++ b/docs/DEV_GETTING_STARTED.md
@@ -32,14 +32,16 @@ When dry run is active:
 
 ## API Keys and LLM Connections
 
-Raypaste offers 2 ways to get LLM completions **direct-to-provider** and in the future **raypaste-api**.
+Raypaste offers direct-to-provider completions today and will support **raypaste-api** in the future.
 You can configure your options in the app settings.
 
 ### Direct to Provider
 
-You can set one or both of [OpenRouter](https://openrouter.ai/) or [Cerebras](https://www.cerebras.ai/) API keys and select which one you want to route your requests through.
+You can set one or more of [OpenRouter](https://openrouter.ai/), [Cerebras](https://www.cerebras.ai/), or [OpenAI](https://platform.openai.com/) API keys and select which one you want to route your requests through.
 
-**(Privacy-first):** Your prompt, inputs, and outputs do not pass through Raypaste's servers and are not stored anywhere in our database. Your request goes from the app to OpenRouter or Cerebras directly and returns directly back to you. Please review OpenRouter and Cerebras' privacy policies on how they will interact with your personal/business data—generally when paying for usage and with settings properly configured this means your data stays private.
+**(Privacy-first):** Your prompt, inputs, and outputs do not pass through Raypaste's servers and are not stored anywhere in our database. Your request goes from the app to the provider you selected and returns directly back to you. Please review each provider's privacy policies on how they will interact with your personal/business data.
+
+Raypaste filters the model picker by provider so only the models currently provisioned and validated for that direct connection are shown. See [MODEL_PROVIDER_COMPLIANCE.md](MODEL_PROVIDER_COMPLIANCE.md) for the current matrix.
 
 ### Raypaste API
 

--- a/docs/MODEL_PROVIDER_COMPLIANCE.md
+++ b/docs/MODEL_PROVIDER_COMPLIANCE.md
@@ -2,21 +2,19 @@
 
 Raypaste direct mode intentionally exposes a provider-scoped model list instead of one shared catalog.
 
-## Current direct-mode model access
+## Current direct-mode behavior
 
-| Provider | Models shown in Raypaste | Notes |
-| --- | --- | --- |
-| OpenRouter | `openai/gpt-oss-120b` | Kept to the currently provisioned OpenRouter arrangement. |
-| Cerebras | `openai/gpt-oss-120b`, `meta-llama/llama-3.1-8b-instruct` | Matches the models currently validated against Cerebras Inference. |
-| OpenAI | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano` | Scoped to the GPT-5 family currently enabled in Raypaste direct mode. |
+- Each provider owns its own allowed-model registry and display order.
+- The registry lives in `src/services/llm/models.ts`.
+- The Settings model picker only shows models returned by the active provider's registry entry.
+- Providers may expose overlapping model ids with provider-specific labels.
 
 ## How filtering works
 
-- The provider registry lives in `src/services/llm/models.ts`.
-- Each direct provider declares its own allowed models and display order.
 - When the active provider changes, Raypaste keeps the current model only if that provider explicitly allows it.
 - If the selected model is not allowed for the newly selected provider, Raypaste automatically falls back to that provider's default model.
-- The Settings model picker renders only the models returned by the active provider registry entry.
+- When persisted settings are loaded, Raypaste normalizes both the provider and model against the current registry.
+- Label lookup is provider-aware so shared model ids can still render provider-specific names in the UI.
 
 ## Why this exists
 
@@ -30,5 +28,5 @@ When provider access changes:
 
 1. Update `src/services/llm/models.ts`.
 2. Add or remove any provider transport logic needed under `src/services/llm/`.
-3. Update `docs/MODEL_PROVIDER_COMPLIANCE.md` so the documented matrix stays in sync with the UI.
+3. Update `docs/MODEL_PROVIDER_COMPLIANCE.md` if the registry behavior, normalization rules, or provider-specific transport assumptions change.
 4. Extend the tests in `src/services/llm/models.test.ts` if the provider list or ordering changes.

--- a/docs/MODEL_PROVIDER_COMPLIANCE.md
+++ b/docs/MODEL_PROVIDER_COMPLIANCE.md
@@ -1,0 +1,34 @@
+# Model Provider Compliance
+
+Raypaste direct mode intentionally exposes a provider-scoped model list instead of one shared catalog.
+
+## Current direct-mode model access
+
+| Provider | Models shown in Raypaste | Notes |
+| --- | --- | --- |
+| OpenRouter | `openai/gpt-oss-120b` | Kept to the currently provisioned OpenRouter arrangement. |
+| Cerebras | `openai/gpt-oss-120b`, `meta-llama/llama-3.1-8b-instruct` | Matches the models currently validated against Cerebras Inference. |
+| OpenAI | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano` | Scoped to the GPT-5 family currently enabled in Raypaste direct mode. |
+
+## How filtering works
+
+- The provider registry lives in `src/services/llm/models.ts`.
+- Each direct provider declares its own allowed models and display order.
+- When the active provider changes, Raypaste keeps the current model only if that provider explicitly allows it.
+- If the selected model is not allowed for the newly selected provider, Raypaste automatically falls back to that provider's default model.
+- The Settings model picker renders only the models returned by the active provider registry entry.
+
+## Why this exists
+
+- Provider access is not uniform across OpenRouter, Cerebras, and OpenAI.
+- A shared model list makes it easy to save an invalid provider/model combination and fail later at request time.
+- Provider-scoped filtering keeps the UI compliant with the models Raypaste currently provisions and validates.
+
+## Updating the registry
+
+When provider access changes:
+
+1. Update `src/services/llm/models.ts`.
+2. Add or remove any provider transport logic needed under `src/services/llm/`.
+3. Update `docs/MODEL_PROVIDER_COMPLIANCE.md` so the documented matrix stays in sync with the UI.
+4. Extend the tests in `src/services/llm/models.test.ts` if the provider list or ordering changes.

--- a/package.json
+++ b/package.json
@@ -66,5 +66,6 @@
     "typescript-eslint": "^8.56.1",
     "vite": "^7.0.4",
     "vitest": "^4.1.1"
-  }
+  },
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raypaste",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -66,6 +66,5 @@
     "typescript-eslint": "^8.56.1",
     "vite": "^7.0.4",
     "vitest": "^4.1.1"
-  },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Raypaste"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "core-graphics 0.23.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Raypaste"
-version = "0.3.1"
+version = "0.3.2"
 description = "An app for fast, and customizable AI completions anywhere on your computer."
 authors = ["Winston Hsiao"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Raypaste",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.raypaste.raypaste",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/lib/core/instantMode.ts
+++ b/src/lib/core/instantMode.ts
@@ -39,7 +39,7 @@ export async function runInstantMode(p: ModeParams) {
     await getLLMClient().stream(
       {
         messages: [
-          { role: "system", content: p.prompt.text },
+          { role: "instruction", content: p.prompt.text },
           { role: "user", content: p.selected_text },
         ],
         model: p.model,

--- a/src/lib/core/reviewMode.ts
+++ b/src/lib/core/reviewMode.ts
@@ -32,7 +32,7 @@ export async function runReviewMode(p: ModeParams) {
     await getLLMClient().stream(
       {
         messages: [
-          { role: "system", content: p.prompt.text },
+          { role: "instruction", content: p.prompt.text },
           { role: "user", content: p.selected_text },
         ],
         model: p.model,

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,9 +21,18 @@ import {
   ComboboxContent,
   ComboboxList,
   ComboboxItem,
+  ComboboxGroup,
   ComboboxEmpty,
+  ComboboxLabel,
 } from "#/components/ui/combobox";
 import { Button } from "#/components/ui/button";
+import {
+  DIRECT_PROVIDER_OPTIONS,
+  getModelLabel,
+  getProviderAccessDescription,
+  getProviderLabel,
+  getProviderModelOptions,
+} from "#/services/llm/models";
 
 export function SettingsPage() {
   const {
@@ -31,6 +40,7 @@ export function SettingsPage() {
     provider,
     openrouterApiKey,
     cerebrasApiKey,
+    openaiApiKey,
     model,
     reviewMode,
     themeMode,
@@ -38,18 +48,13 @@ export function SettingsPage() {
     setProvider,
     setOpenrouterApiKey,
     setCerebrasApiKey,
+    setOpenaiApiKey,
     setModel,
     setReviewMode,
     setThemeMode,
   } = useSettingsStore();
 
-  const modelOptions = [
-    { value: "openai/gpt-oss-120b", label: "GPT OSS 120B" },
-    {
-      value: "meta-llama/llama-3.1-8b-instruct",
-      label: "Llama 3.1 8B Instruct",
-    },
-  ];
+  const modelOptions = getProviderModelOptions(provider);
 
   const { prompts, defaultPromptId, setDefaultPrompt } = usePromptsStore();
   const { apps, hiddenAppBundleIds, unhideApp } = useAppsStore();
@@ -79,15 +84,20 @@ export function SettingsPage() {
     (m) => m.label,
   );
 
-  const modelLabelForId = (id: string) =>
-    modelOptions.find((m) => m.value === id)?.label ?? id;
+  const modelLabelForId = (id: string) => getModelLabel(id);
 
   const currentKey =
-    provider === LLM_PROVIDER.Cerebras ? cerebrasApiKey : openrouterApiKey;
+    provider === LLM_PROVIDER.Cerebras
+      ? cerebrasApiKey
+      : provider === LLM_PROVIDER.OpenAI
+        ? openaiApiKey
+        : openrouterApiKey;
   const setCurrentKey =
     provider === LLM_PROVIDER.Cerebras
       ? setCerebrasApiKey
-      : setOpenrouterApiKey;
+      : provider === LLM_PROVIDER.OpenAI
+        ? setOpenaiApiKey
+        : setOpenrouterApiKey;
 
   const themeOptions: {
     value: ThemeMode;
@@ -174,12 +184,15 @@ export function SettingsPage() {
         <section className="space-y-3">
           <h2 className="text-foreground text-sm font-semibold">Provider</h2>
           <div className="flex gap-2">
-            {Object.values(LLM_PROVIDER).map((p) => (
+            {DIRECT_PROVIDER_OPTIONS.map((p) => (
               <Button
                 key={p}
                 type="button"
                 variant="outline"
-                onClick={() => setProvider(p)}
+                onClick={() => {
+                  setProvider(p);
+                  setModelQuery("");
+                }}
                 className={cn(
                   "capitalize",
                   provider === p
@@ -187,7 +200,7 @@ export function SettingsPage() {
                     : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground dark:hover:bg-input/40",
                 )}
               >
-                {p === LLM_PROVIDER.OpenRouter ? "OpenRouter" : "Cerebras"}
+                {getProviderLabel(p)}
               </Button>
             ))}
           </div>
@@ -198,8 +211,7 @@ export function SettingsPage() {
       {mode === "direct" && (
         <section className="space-y-2">
           <h2 className="text-foreground text-xs font-medium">
-            {provider === LLM_PROVIDER.OpenRouter ? "OpenRouter" : "Cerebras"}{" "}
-            API Key
+            {getProviderLabel(provider)} API Key
           </h2>
           <div className="flex h-8 gap-2">
             <input
@@ -275,6 +287,49 @@ export function SettingsPage() {
         </div>
       </section>
 
+      {/* Model */}
+      <section className="space-y-3">
+        <h2 className="text-foreground text-sm font-semibold">Model</h2>
+        <Combobox
+          value={model}
+          itemToStringLabel={modelLabelForId}
+          onValueChange={(id) => {
+            if (id != null && id !== "") setModel(id);
+          }}
+          onOpenChange={modelSearch.onOpenChange}
+          onInputValueChange={(val) => setModelQuery(val)}
+        >
+          <ComboboxInput
+            placeholder="Select a model..."
+            showTrigger
+            className="w-full"
+            onInput={modelSearch.markSearchDirtyFromInput}
+          />
+          <ComboboxContent>
+            {filteredModelOptions.length === 0 && (
+              <ComboboxEmpty>No models found</ComboboxEmpty>
+            )}
+            <ComboboxList>
+              <ComboboxGroup>
+                <ComboboxLabel>{getProviderLabel(provider)}</ComboboxLabel>
+                {filteredModelOptions.map((m) => (
+                  <ComboboxItem
+                    key={m.value}
+                    value={m.value}
+                    className="py-2 pl-3"
+                  >
+                    {m.label}
+                  </ComboboxItem>
+                ))}
+              </ComboboxGroup>
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+        <p className="text-muted-foreground text-xs">
+          {getProviderAccessDescription(provider)}
+        </p>
+      </section>
+
       {/* Default Prompt */}
       <section className="space-y-3">
         <h2 className="text-foreground text-sm font-semibold">
@@ -311,43 +366,6 @@ export function SettingsPage() {
         <p className="text-muted-foreground text-xs">
           Used when no website prompt or app-specific prompt applies
         </p>
-      </section>
-
-      {/* Model */}
-      <section className="space-y-3">
-        <h2 className="text-foreground text-sm font-semibold">Model</h2>
-        <Combobox
-          value={model}
-          itemToStringLabel={modelLabelForId}
-          onValueChange={(id) => {
-            if (id != null && id !== "") setModel(id);
-          }}
-          onOpenChange={modelSearch.onOpenChange}
-          onInputValueChange={(val) => setModelQuery(val)}
-        >
-          <ComboboxInput
-            placeholder="Select a model..."
-            showTrigger
-            className="w-full"
-            onInput={modelSearch.markSearchDirtyFromInput}
-          />
-          <ComboboxContent>
-            {filteredModelOptions.length === 0 && (
-              <ComboboxEmpty>No models found</ComboboxEmpty>
-            )}
-            <ComboboxList>
-              {filteredModelOptions.map((m) => (
-                <ComboboxItem
-                  key={m.value}
-                  value={m.value}
-                  className="py-2 pl-3"
-                >
-                  {m.label}
-                </ComboboxItem>
-              ))}
-            </ComboboxList>
-          </ComboboxContent>
-        </Combobox>
       </section>
 
       {/* Import & Export */}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -84,7 +84,7 @@ export function SettingsPage() {
     (m) => m.label,
   );
 
-  const modelLabelForId = (id: string) => getModelLabel(id);
+  const modelLabelForId = (id: string) => getModelLabel(provider, id);
 
   const currentKey =
     provider === LLM_PROVIDER.Cerebras

--- a/src/pages/history/DetailDialog.tsx
+++ b/src/pages/history/DetailDialog.tsx
@@ -23,6 +23,8 @@ import {
 import { toast } from "#/hooks/useToast";
 import { cn } from "#/lib/utils";
 import { usePromptsStore } from "#/stores";
+import { getProviderLabel } from "#/services/llm/models";
+import { type LLMProvider, LLM_PROVIDER } from "#/services/llm/types";
 import {
   findWebsiteSiteIdForCompletion,
   promptSourceDisplayLabel,
@@ -130,6 +132,12 @@ function SectionHeader({
 
 function countVisible(v: Record<ColumnKey, boolean>) {
   return (["input", "output", "final"] as const).filter((k) => v[k]).length;
+}
+
+function formatProviderLabel(provider: string): string {
+  return Object.values(LLM_PROVIDER).includes(provider as LLMProvider)
+    ? getProviderLabel(provider as LLMProvider)
+    : provider;
 }
 
 function ResizableTwoColumn({
@@ -244,7 +252,7 @@ function DetailDialogMetadataHeader({
           <span className="text-sky-500">Instant</span>
         )}
         <span>·</span>
-        <span className="capitalize">{row.provider}</span>
+        <span>{formatProviderLabel(row.provider)}</span>
         <span>·</span>
         <span className="font-mono">{row.model}</span>
       </div>

--- a/src/services/llm/cerebras.ts
+++ b/src/services/llm/cerebras.ts
@@ -1,5 +1,6 @@
 import type { LLMClient, LLMCompletion, LLMRequest } from "./types";
 import { chatCompletionBody } from "./chatCompletionBody";
+import { getCompletionText, parseSSEStream } from "./streaming";
 
 const BASE_URL = "https://api.cerebras.ai/v1/chat/completions";
 
@@ -23,45 +24,6 @@ function cerebrasRequestBody(req: LLMRequest, stream: boolean) {
   return { ...base, model: toCerebrasModelId(base.model) };
 }
 
-async function parseSSEStream(
-  body: ReadableStream<Uint8Array>,
-  onChunk: (text: string) => void,
-) {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
-    for (const line of lines) {
-      if (!line.startsWith("data:")) {
-        continue;
-      }
-
-      const raw = line.slice(5).trim();
-      if (raw === "[DONE]") {
-        break;
-      }
-
-      try {
-        const chunk = JSON.parse(raw);
-        const delta = chunk.choices?.[0]?.delta?.content;
-        if (delta) {
-          onChunk(delta as string);
-        }
-      } catch {
-        // ignore malformed chunks
-      }
-    }
-  }
-}
-
 export const cerebrasClient: LLMClient = {
   async complete(
     req: LLMRequest,
@@ -81,12 +43,12 @@ export const cerebrasClient: LLMClient = {
       throw new Error(`Cerebras error: ${res.status}`);
     }
     const data = (await res.json()) as {
-      choices: { message: { content: string } }[];
+      choices?: Array<{ message?: { content?: unknown } }>;
       usage?: { prompt_tokens?: number; completion_tokens?: number };
     };
 
     return {
-      text: data.choices[0].message.content,
+      text: getCompletionText(data),
       usage: {
         input_tokens: data.usage?.prompt_tokens ?? null,
         output_tokens: data.usage?.completion_tokens ?? null,

--- a/src/services/llm/cerebras.ts
+++ b/src/services/llm/cerebras.ts
@@ -1,4 +1,9 @@
-import type { LLMClient, LLMCompletion, LLMRequest } from "./types";
+import {
+  LLM_PROVIDER,
+  type LLMClient,
+  type LLMCompletion,
+  type LLMRequest,
+} from "./types";
 import { chatCompletionBody } from "./chatCompletionBody";
 import { getCompletionText, parseSSEStream } from "./streaming";
 
@@ -20,7 +25,7 @@ function toCerebrasModelId(model: string): string {
 }
 
 function cerebrasRequestBody(req: LLMRequest, stream: boolean) {
-  const base = chatCompletionBody(req, stream);
+  const base = chatCompletionBody(LLM_PROVIDER.Cerebras, req, stream);
   return { ...base, model: toCerebrasModelId(base.model) };
 }
 

--- a/src/services/llm/chatCompletionBody.test.ts
+++ b/src/services/llm/chatCompletionBody.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { chatCompletionBody } from "./chatCompletionBody";
+import { LLM_PROVIDER, type LLMRequest } from "./types";
+
+const request: LLMRequest = {
+  model: "gpt-5.4-mini",
+  dryRunMetadata: {
+    promptName: "Test Prompt",
+  },
+  messages: [
+    { role: "instruction", content: "Follow the prompt." },
+    { role: "user", content: "Hello" },
+  ],
+};
+
+describe("chatCompletionBody", () => {
+  it("serializes instruction messages as developer for OpenAI", () => {
+    expect(chatCompletionBody(LLM_PROVIDER.OpenAI, request, false)).toEqual({
+      model: "gpt-5.4-mini",
+      messages: [
+        { role: "developer", content: "Follow the prompt." },
+        { role: "user", content: "Hello" },
+      ],
+      stream: false,
+    });
+  });
+
+  it("serializes instruction messages as system for OpenRouter-compatible providers", () => {
+    expect(chatCompletionBody(LLM_PROVIDER.OpenRouter, request, true)).toEqual({
+      model: "gpt-5.4-mini",
+      messages: [
+        { role: "system", content: "Follow the prompt." },
+        { role: "user", content: "Hello" },
+      ],
+      stream: true,
+    });
+  });
+
+  it("does not send dry-run metadata or reasoning_effort", () => {
+    const body = chatCompletionBody(LLM_PROVIDER.OpenAI, request, false) as {
+      dryRunMetadata?: unknown;
+      reasoning_effort?: unknown;
+    };
+
+    expect(body.dryRunMetadata).toBeUndefined();
+    expect(body.reasoning_effort).toBeUndefined();
+  });
+});

--- a/src/services/llm/chatCompletionBody.ts
+++ b/src/services/llm/chatCompletionBody.ts
@@ -1,8 +1,28 @@
 import type { LLMRequest } from "./types";
 
+function normalizeModelId(model: string): string {
+  return model.startsWith("openai/") ? model.slice("openai/".length) : model;
+}
+
+function getReasoningEffort(model: string): string | null {
+  const normalized = normalizeModelId(model).toLowerCase();
+  if (normalized === "gpt-5.4" || normalized.startsWith("gpt-5.4-")) {
+    return "none";
+  }
+
+  if (normalized === "gpt-5" || normalized.startsWith("gpt-5-")) {
+    return "minimal";
+  }
+
+  return null;
+}
+
 /** JSON body for OpenAI-compatible chat/completions (strips Raypaste-only fields). */
 export function chatCompletionBody(req: LLMRequest, stream: boolean) {
   const { dryRunMetadata, ...rest } = req;
   void dryRunMetadata;
-  return { ...rest, stream };
+  const reasoningEffort = getReasoningEffort(rest.model);
+  return reasoningEffort
+    ? { ...rest, stream, reasoning_effort: reasoningEffort }
+    : { ...rest, stream };
 }

--- a/src/services/llm/chatCompletionBody.ts
+++ b/src/services/llm/chatCompletionBody.ts
@@ -1,28 +1,32 @@
-import type { LLMRequest } from "./types";
+import { LLM_PROVIDER, type LLMProvider, type LLMRequest } from "./types";
 
-function normalizeModelId(model: string): string {
-  return model.startsWith("openai/") ? model.slice("openai/".length) : model;
+function toProviderRole(
+  provider: LLMProvider,
+  role: LLMRequest["messages"][number]["role"],
+): "developer" | "system" | "user" | "assistant" {
+  switch (role) {
+    case "instruction":
+      return provider === LLM_PROVIDER.OpenAI ? "developer" : "system";
+    case "user":
+    case "assistant":
+      return role;
+  }
 }
 
-function getReasoningEffort(model: string): string | null {
-  const normalized = normalizeModelId(model).toLowerCase();
-  if (normalized === "gpt-5.4" || normalized.startsWith("gpt-5.4-")) {
-    return "none";
-  }
-
-  if (normalized === "gpt-5" || normalized.startsWith("gpt-5-")) {
-    return "minimal";
-  }
-
-  return null;
-}
-
-/** JSON body for OpenAI-compatible chat/completions (strips Raypaste-only fields). */
-export function chatCompletionBody(req: LLMRequest, stream: boolean) {
-  const { dryRunMetadata, ...rest } = req;
+/** JSON body for chat/completions (strips Raypaste-only fields). */
+export function chatCompletionBody(
+  provider: LLMProvider,
+  req: LLMRequest,
+  stream: boolean,
+) {
+  const { dryRunMetadata, messages, ...rest } = req;
   void dryRunMetadata;
-  const reasoningEffort = getReasoningEffort(rest.model);
-  return reasoningEffort
-    ? { ...rest, stream, reasoning_effort: reasoningEffort }
-    : { ...rest, stream };
+  return {
+    ...rest,
+    messages: messages.map((message) => ({
+      ...message,
+      role: toProviderRole(provider, message.role),
+    })),
+    stream,
+  };
 }

--- a/src/services/llm/index.ts
+++ b/src/services/llm/index.ts
@@ -1,6 +1,7 @@
 import { useSettingsStore } from "#/stores";
 import { openrouterClient } from "./openrouter";
 import { cerebrasClient } from "./cerebras";
+import { openaiClient } from "./openai";
 import { raypasteApiClient } from "./raypaste-api";
 import { dryRunClient } from "./dryRun";
 import type { LLMClient } from "./types";
@@ -18,7 +19,15 @@ export function getLLMClient(): LLMClient {
     return raypasteApiClient;
   }
 
-  return provider === LLM_PROVIDER.Cerebras ? cerebrasClient : openrouterClient;
+  switch (provider) {
+    case LLM_PROVIDER.Cerebras:
+      return cerebrasClient;
+    case LLM_PROVIDER.OpenAI:
+      return openaiClient;
+    case LLM_PROVIDER.OpenRouter:
+    default:
+      return openrouterClient;
+  }
 }
 
 export function getApiKey(): string {
@@ -26,10 +35,18 @@ export function getApiKey(): string {
     return "dry-run";
   }
 
-  const { provider, openrouterApiKey, cerebrasApiKey } =
+  const { provider, openrouterApiKey, cerebrasApiKey, openaiApiKey } =
     useSettingsStore.getState();
 
-  return provider === LLM_PROVIDER.Cerebras ? cerebrasApiKey : openrouterApiKey;
+  switch (provider) {
+    case LLM_PROVIDER.Cerebras:
+      return cerebrasApiKey;
+    case LLM_PROVIDER.OpenAI:
+      return openaiApiKey;
+    case LLM_PROVIDER.OpenRouter:
+    default:
+      return openrouterApiKey;
+  }
 }
 
 export type { LLMClient, LLMRequest, LLMMessage } from "./types";

--- a/src/services/llm/models.test.ts
+++ b/src/services/llm/models.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DIRECT_PROVIDER,
+  getDefaultModelForProvider,
+  getModelLabel,
+  getProviderModelOptions,
+  normalizeLLMProvider,
+  normalizeProviderModel,
+} from "./models";
+import { LLM_PROVIDER } from "./types";
+
+describe("provider model registry", () => {
+  it("filters OpenRouter models to the current provisioned set", () => {
+    expect(getProviderModelOptions(LLM_PROVIDER.OpenRouter)).toEqual([
+      { value: "openai/gpt-oss-120b", label: "GPT OSS 120B" },
+    ]);
+  });
+
+  it("filters Cerebras models to the validated compatibility set", () => {
+    expect(getProviderModelOptions(LLM_PROVIDER.Cerebras)).toEqual([
+      { value: "openai/gpt-oss-120b", label: "GPT OSS 120B" },
+      {
+        value: "meta-llama/llama-3.1-8b-instruct",
+        label: "Llama 3.1 8B Instruct",
+      },
+    ]);
+  });
+
+  it("orders OpenAI direct models from newest flagship to smaller variants", () => {
+    expect(getProviderModelOptions(LLM_PROVIDER.OpenAI)).toEqual([
+      { value: "gpt-5.4", label: "GPT-5.4" },
+      { value: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+      { value: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
+      { value: "gpt-5", label: "GPT-5" },
+      { value: "gpt-5-mini", label: "GPT-5 Mini" },
+      { value: "gpt-5-nano", label: "GPT-5 Nano" },
+    ]);
+  });
+
+  it("normalizes invalid provider-model combinations to the provider default", () => {
+    expect(
+      normalizeProviderModel(LLM_PROVIDER.OpenAI, "openai/gpt-oss-120b"),
+    ).toBe(getDefaultModelForProvider(LLM_PROVIDER.OpenAI));
+  });
+
+  it("maps known model ids to friendly labels", () => {
+    expect(getModelLabel("gpt-5.4-mini")).toBe("GPT-5.4 Mini");
+  });
+
+  it("falls back to the default direct provider for invalid persisted values", () => {
+    expect(normalizeLLMProvider("not-a-provider")).toBe(DEFAULT_DIRECT_PROVIDER);
+  });
+});

--- a/src/services/llm/models.test.ts
+++ b/src/services/llm/models.test.ts
@@ -13,6 +13,10 @@ describe("provider model registry", () => {
   it("filters OpenRouter models to the current provisioned set", () => {
     expect(getProviderModelOptions(LLM_PROVIDER.OpenRouter)).toEqual([
       { value: "openai/gpt-oss-120b", label: "GPT OSS 120B" },
+      {
+        value: "meta-llama/llama-3.1-8b-instruct",
+        label: "Llama 3.1 8B",
+      },
     ]);
   });
 
@@ -34,6 +38,7 @@ describe("provider model registry", () => {
       { value: "gpt-5", label: "GPT-5" },
       { value: "gpt-5-mini", label: "GPT-5 Mini" },
       { value: "gpt-5-nano", label: "GPT-5 Nano" },
+      { value: "gpt-4o-mini", label: "GPT-4o Mini" },
     ]);
   });
 

--- a/src/services/llm/models.test.ts
+++ b/src/services/llm/models.test.ts
@@ -48,11 +48,33 @@ describe("provider model registry", () => {
     ).toBe(getDefaultModelForProvider(LLM_PROVIDER.OpenAI));
   });
 
-  it("maps known model ids to friendly labels", () => {
-    expect(getModelLabel("gpt-5.4-mini")).toBe("GPT-5.4 Mini");
+  it("maps known model ids to provider-aware friendly labels", () => {
+    expect(getModelLabel(LLM_PROVIDER.OpenAI, "gpt-5.4-mini")).toBe(
+      "GPT-5.4 Mini",
+    );
+  });
+
+  it("keeps duplicate ids provider-scoped when resolving labels", () => {
+    expect(
+      getModelLabel(
+        LLM_PROVIDER.OpenRouter,
+        "meta-llama/llama-3.1-8b-instruct",
+      ),
+    ).toBe("Llama 3.1 8B");
+    expect(
+      getModelLabel(LLM_PROVIDER.Cerebras, "meta-llama/llama-3.1-8b-instruct"),
+    ).toBe("Llama 3.1 8B Instruct");
+  });
+
+  it("falls back to the raw model id when a provider label is unknown", () => {
+    expect(getModelLabel(LLM_PROVIDER.OpenAI, "unknown-model")).toBe(
+      "unknown-model",
+    );
   });
 
   it("falls back to the default direct provider for invalid persisted values", () => {
-    expect(normalizeLLMProvider("not-a-provider")).toBe(DEFAULT_DIRECT_PROVIDER);
+    expect(normalizeLLMProvider("not-a-provider")).toBe(
+      DEFAULT_DIRECT_PROVIDER,
+    );
   });
 });

--- a/src/services/llm/models.ts
+++ b/src/services/llm/models.ts
@@ -1,0 +1,115 @@
+import { LLM_PROVIDER, type LLMProvider } from "./types";
+
+export interface ProviderModelOption {
+  value: string;
+  label: string;
+}
+
+export const DIRECT_PROVIDER_OPTIONS = [
+  LLM_PROVIDER.OpenRouter,
+  LLM_PROVIDER.Cerebras,
+  LLM_PROVIDER.OpenAI,
+] as const satisfies readonly LLMProvider[];
+
+const PROVIDER_LABELS: Record<LLMProvider, string> = {
+  [LLM_PROVIDER.OpenRouter]: "OpenRouter",
+  [LLM_PROVIDER.Cerebras]: "Cerebras",
+  [LLM_PROVIDER.OpenAI]: "OpenAI",
+};
+
+const PROVIDER_MODEL_OPTIONS: Record<LLMProvider, ProviderModelOption[]> = {
+  [LLM_PROVIDER.OpenRouter]: [
+    { value: "openai/gpt-oss-120b", label: "GPT OSS 120B" },
+    { value: "meta-llama/llama-3.1-8b-instruct", label: "Llama 3.1 8B" },
+  ],
+  [LLM_PROVIDER.Cerebras]: [
+    { value: "openai/gpt-oss-120b", label: "GPT OSS 120B" },
+    {
+      value: "meta-llama/llama-3.1-8b-instruct",
+      label: "Llama 3.1 8B Instruct",
+    },
+  ],
+  [LLM_PROVIDER.OpenAI]: [
+    { value: "gpt-5.4", label: "GPT-5.4" },
+    { value: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+    { value: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
+    { value: "gpt-5", label: "GPT-5" },
+    { value: "gpt-5-mini", label: "GPT-5 Mini" },
+    { value: "gpt-5-nano", label: "GPT-5 Nano" },
+    { value: "gpt-4o-mini", label: "GPT-4o Mini" },
+  ],
+};
+
+export const DEFAULT_DIRECT_PROVIDER = LLM_PROVIDER.OpenRouter;
+
+const ALL_PROVIDER_MODEL_OPTIONS = Object.values(PROVIDER_MODEL_OPTIONS).flat();
+
+export function isLLMProvider(value: unknown): value is LLMProvider {
+  return (
+    typeof value === "string" &&
+    Object.values(LLM_PROVIDER).includes(value as LLMProvider)
+  );
+}
+
+export function normalizeLLMProvider(value: unknown): LLMProvider {
+  return isLLMProvider(value) ? value : DEFAULT_DIRECT_PROVIDER;
+}
+
+export function getProviderLabel(provider: LLMProvider): string {
+  return PROVIDER_LABELS[provider];
+}
+
+export function getProviderModelOptions(
+  provider: LLMProvider,
+): ProviderModelOption[] {
+  return PROVIDER_MODEL_OPTIONS[provider];
+}
+
+export function getModelLabel(model: string): string {
+  return (
+    ALL_PROVIDER_MODEL_OPTIONS.find((option) => option.value === model)
+      ?.label ?? model
+  );
+}
+
+export function getDefaultModelForProvider(provider: LLMProvider): string {
+  switch (provider) {
+    case LLM_PROVIDER.OpenRouter:
+      return "openai/gpt-oss-120b";
+    case LLM_PROVIDER.Cerebras:
+      return "openai/gpt-oss-120b";
+    case LLM_PROVIDER.OpenAI:
+      return "gpt-5-nano";
+    default:
+      return (PROVIDER_MODEL_OPTIONS[provider][0] as ProviderModelOption).value;
+  }
+}
+
+export function isModelAllowedForProvider(
+  provider: LLMProvider,
+  model: string,
+): boolean {
+  return PROVIDER_MODEL_OPTIONS[provider].some(
+    (option) => option.value === model,
+  );
+}
+
+export function normalizeProviderModel(
+  provider: LLMProvider,
+  model: unknown,
+): string {
+  return typeof model === "string" && isModelAllowedForProvider(provider, model)
+    ? model
+    : getDefaultModelForProvider(provider);
+}
+
+export function getProviderAccessDescription(provider: LLMProvider): string {
+  switch (provider) {
+    case LLM_PROVIDER.OpenRouter:
+      return "Select from models currently supported for OpenRouter direct mode.";
+    case LLM_PROVIDER.Cerebras:
+      return "Selet from models currently validated against the Cerebras Inference API.";
+    case LLM_PROVIDER.OpenAI:
+      return "Select from supported OpenAI models.";
+  }
+}

--- a/src/services/llm/models.ts
+++ b/src/services/llm/models.ts
@@ -42,8 +42,6 @@ const PROVIDER_MODEL_OPTIONS: Record<LLMProvider, ProviderModelOption[]> = {
 
 export const DEFAULT_DIRECT_PROVIDER = LLM_PROVIDER.OpenRouter;
 
-const ALL_PROVIDER_MODEL_OPTIONS = Object.values(PROVIDER_MODEL_OPTIONS).flat();
-
 export function isLLMProvider(value: unknown): value is LLMProvider {
   return (
     typeof value === "string" &&
@@ -65,9 +63,9 @@ export function getProviderModelOptions(
   return PROVIDER_MODEL_OPTIONS[provider];
 }
 
-export function getModelLabel(model: string): string {
+export function getModelLabel(provider: LLMProvider, model: string): string {
   return (
-    ALL_PROVIDER_MODEL_OPTIONS.find((option) => option.value === model)
+    PROVIDER_MODEL_OPTIONS[provider].find((option) => option.value === model)
       ?.label ?? model
   );
 }
@@ -108,7 +106,7 @@ export function getProviderAccessDescription(provider: LLMProvider): string {
     case LLM_PROVIDER.OpenRouter:
       return "Select from models currently supported for OpenRouter direct mode.";
     case LLM_PROVIDER.Cerebras:
-      return "Selet from models currently validated against the Cerebras Inference API.";
+      return "Select from models currently validated against the Cerebras Inference API.";
     case LLM_PROVIDER.OpenAI:
       return "Select from supported OpenAI models.";
   }

--- a/src/services/llm/openai.ts
+++ b/src/services/llm/openai.ts
@@ -1,6 +1,7 @@
 import type { LLMClient, LLMCompletion, LLMRequest } from "./types";
 import { chatCompletionBody } from "./chatCompletionBody";
 import { getCompletionText, parseSSEStream } from "./streaming";
+import { LLM_PROVIDER } from "./types";
 
 const BASE_URL = "https://api.openai.com/v1/chat/completions";
 
@@ -16,7 +17,7 @@ export const openaiClient: LLMClient = {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify(chatCompletionBody(req, false)),
+      body: JSON.stringify(chatCompletionBody(LLM_PROVIDER.OpenAI, req, false)),
       signal,
     });
 
@@ -50,7 +51,7 @@ export const openaiClient: LLMClient = {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify(chatCompletionBody(req, true)),
+      body: JSON.stringify(chatCompletionBody(LLM_PROVIDER.OpenAI, req, true)),
       signal,
     });
 

--- a/src/services/llm/openai.ts
+++ b/src/services/llm/openai.ts
@@ -2,13 +2,9 @@ import type { LLMClient, LLMCompletion, LLMRequest } from "./types";
 import { chatCompletionBody } from "./chatCompletionBody";
 import { getCompletionText, parseSSEStream } from "./streaming";
 
-const BASE_URL = "https://openrouter.ai/api/v1/chat/completions";
-const EXTRA_HEADERS = {
-  "HTTP-Referer": "https://raypaste.com",
-  "X-Title": "Raypaste",
-};
+const BASE_URL = "https://api.openai.com/v1/chat/completions";
 
-export const openrouterClient: LLMClient = {
+export const openaiClient: LLMClient = {
   async complete(
     req: LLMRequest,
     apiKey: string,
@@ -19,12 +15,14 @@ export const openrouterClient: LLMClient = {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
-        ...EXTRA_HEADERS,
       },
       body: JSON.stringify(chatCompletionBody(req, false)),
       signal,
     });
-    if (!res.ok) throw new Error(`OpenRouter error: ${res.status}`);
+
+    if (!res.ok) {
+      throw new Error(`OpenAI error: ${res.status}`);
+    }
 
     const data = (await res.json()) as {
       choices?: Array<{ message?: { content?: unknown } }>;
@@ -51,13 +49,13 @@ export const openrouterClient: LLMClient = {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
-        ...EXTRA_HEADERS,
       },
       body: JSON.stringify(chatCompletionBody(req, true)),
       signal,
     });
+
     if (!res.ok) {
-      throw new Error(`OpenRouter error: ${res.status}`);
+      throw new Error(`OpenAI error: ${res.status}`);
     }
 
     await parseSSEStream(res.body!, onChunk);

--- a/src/services/llm/openrouter.ts
+++ b/src/services/llm/openrouter.ts
@@ -1,4 +1,9 @@
-import type { LLMClient, LLMCompletion, LLMRequest } from "./types";
+import {
+  LLM_PROVIDER,
+  type LLMClient,
+  type LLMCompletion,
+  type LLMRequest,
+} from "./types";
 import { chatCompletionBody } from "./chatCompletionBody";
 import { getCompletionText, parseSSEStream } from "./streaming";
 
@@ -21,7 +26,9 @@ export const openrouterClient: LLMClient = {
         Authorization: `Bearer ${apiKey}`,
         ...EXTRA_HEADERS,
       },
-      body: JSON.stringify(chatCompletionBody(req, false)),
+      body: JSON.stringify(
+        chatCompletionBody(LLM_PROVIDER.OpenRouter, req, false),
+      ),
       signal,
     });
     if (!res.ok) throw new Error(`OpenRouter error: ${res.status}`);
@@ -53,7 +60,9 @@ export const openrouterClient: LLMClient = {
         Authorization: `Bearer ${apiKey}`,
         ...EXTRA_HEADERS,
       },
-      body: JSON.stringify(chatCompletionBody(req, true)),
+      body: JSON.stringify(
+        chatCompletionBody(LLM_PROVIDER.OpenRouter, req, true),
+      ),
       signal,
     });
     if (!res.ok) {

--- a/src/services/llm/streaming.test.ts
+++ b/src/services/llm/streaming.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getCompletionText, parseSSEStream } from "./streaming";
+
+function streamFromLines(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(`${line}\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("streaming compatibility parsing", () => {
+  it("extracts text from array/object chat completion payloads", () => {
+    expect(
+      getCompletionText({
+        choices: [
+          {
+            message: {
+              content: [
+                { type: "output_text", text: "Hello" },
+                { type: "output_text", text: " world" },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toBe("Hello world");
+  });
+
+  it("streams GPT-5 style content parts", async () => {
+    let seen = "";
+
+    await parseSSEStream(
+      streamFromLines([
+        'data: {"choices":[{"delta":{"content":[{"type":"output_text","text":"Hello"},{"type":"output_text","text":" world"}]}}]}',
+        "data: [DONE]",
+      ]),
+      (chunk) => {
+        seen += chunk;
+      },
+    );
+
+    expect(seen).toBe("Hello world");
+  });
+});

--- a/src/services/llm/streaming.ts
+++ b/src/services/llm/streaming.ts
@@ -1,0 +1,91 @@
+function extractContentText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => extractContentText(item)).join("");
+  }
+
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return [
+      extractContentText(record.text),
+      extractContentText(record.content),
+      extractContentText(record.output_text),
+      extractContentText(record.value),
+    ].join("");
+  }
+
+  return "";
+}
+
+export function getCompletionText(data: {
+  choices?: Array<{ message?: { content?: unknown } }>;
+}): string {
+  return extractContentText(data.choices?.[0]?.message?.content);
+}
+
+export async function parseSSEStream(
+  body: ReadableStream<Uint8Array>,
+  onChunk: (text: string) => void,
+) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (line === "" || line.startsWith(":") || !line.startsWith("data:")) {
+        continue;
+      }
+
+      const raw = line.slice(5).trim();
+      if (raw === "[DONE]") {
+        return;
+      }
+
+      let chunk: {
+        error?: { message?: string };
+        choices?: Array<{
+          finish_reason?: string;
+          delta?: { content?: unknown };
+          message?: { content?: unknown };
+        }>;
+      };
+
+      try {
+        chunk = JSON.parse(raw) as typeof chunk;
+      } catch {
+        continue;
+      }
+
+      if (chunk.error?.message) {
+        throw new Error(chunk.error.message);
+      }
+
+      for (const choice of chunk.choices ?? []) {
+        if (choice.finish_reason === "error") {
+          throw new Error("stream terminated with an error");
+        }
+
+        const content =
+          extractContentText(choice.delta?.content) ||
+          extractContentText(choice.message?.content);
+
+        if (content) {
+          onChunk(content);
+        }
+      }
+    }
+  }
+}

--- a/src/services/llm/types.ts
+++ b/src/services/llm/types.ts
@@ -1,6 +1,7 @@
 export const LLM_PROVIDER = {
   OpenRouter: "openrouter",
   Cerebras: "cerebras",
+  OpenAI: "openai",
 } as const;
 
 export type LLMProvider = (typeof LLM_PROVIDER)[keyof typeof LLM_PROVIDER];

--- a/src/services/llm/types.ts
+++ b/src/services/llm/types.ts
@@ -7,7 +7,7 @@ export const LLM_PROVIDER = {
 export type LLMProvider = (typeof LLM_PROVIDER)[keyof typeof LLM_PROVIDER];
 
 export interface LLMMessage {
-  role: "system" | "user" | "assistant";
+  role: "instruction" | "user" | "assistant";
   content: string;
 }
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { LLM_PROVIDER, type LLMProvider } from "#/services/llm/types";
+import type { LLMProvider } from "#/services/llm/types";
+import {
+  DEFAULT_DIRECT_PROVIDER,
+  normalizeLLMProvider,
+  normalizeProviderModel,
+} from "#/services/llm/models";
 
 export type ThemeMode = "light" | "dark" | "auto";
 
@@ -9,6 +14,7 @@ interface SettingsState {
   provider: LLMProvider;
   openrouterApiKey: string;
   cerebrasApiKey: string;
+  openaiApiKey: string;
   model: string;
   reviewMode: boolean;
   themeMode: ThemeMode;
@@ -16,6 +22,7 @@ interface SettingsState {
   setProvider: (provider: LLMProvider) => void;
   setOpenrouterApiKey: (key: string) => void;
   setCerebrasApiKey: (key: string) => void;
+  setOpenaiApiKey: (key: string) => void;
   setModel: (model: string) => void;
   setReviewMode: (reviewMode: boolean) => void;
   setThemeMode: (themeMode: ThemeMode) => void;
@@ -25,17 +32,29 @@ export const useSettingsStore = create<SettingsState>()(
   persist(
     (set) => ({
       mode: "direct",
-      provider: LLM_PROVIDER.OpenRouter,
+      provider: DEFAULT_DIRECT_PROVIDER,
       openrouterApiKey: "",
       cerebrasApiKey: "",
-      model: "openai/gpt-oss-120b",
+      openaiApiKey: "",
+      model: normalizeProviderModel(
+        DEFAULT_DIRECT_PROVIDER,
+        "openai/gpt-oss-120b",
+      ),
       reviewMode: false,
       themeMode: "auto",
       setMode: (mode) => set({ mode }),
-      setProvider: (provider) => set({ provider }),
+      setProvider: (provider) =>
+        set((state) => ({
+          provider,
+          model: normalizeProviderModel(provider, state.model),
+        })),
       setOpenrouterApiKey: (openrouterApiKey) => set({ openrouterApiKey }),
       setCerebrasApiKey: (cerebrasApiKey) => set({ cerebrasApiKey }),
-      setModel: (model) => set({ model }),
+      setOpenaiApiKey: (openaiApiKey) => set({ openaiApiKey }),
+      setModel: (model) =>
+        set((state) => ({
+          model: normalizeProviderModel(state.provider, model),
+        })),
       setReviewMode: (reviewMode) => set({ reviewMode }),
       setThemeMode: (themeMode) => set({ themeMode }),
     }),
@@ -45,10 +64,13 @@ export const useSettingsStore = create<SettingsState>()(
         const persisted = (persistedState ?? {}) as Partial<SettingsState> & {
           reviewMode?: unknown;
         };
+        const provider = normalizeLLMProvider(persisted.provider);
 
         return {
           ...currentState,
           ...persisted,
+          provider,
+          model: normalizeProviderModel(provider, persisted.model),
           reviewMode:
             typeof persisted.reviewMode === "boolean"
               ? persisted.reviewMode


### PR DESCRIPTION
## Background

Raypaste’s “direct-to-provider” mode now supports OpenAI in addition to OpenRouter and Cerebras. Provider-scoped model filtering is added to ensure the UI only shows models validated/provisioned for the selected direct connection.

## Changes

- **Docs**
  - Updated README and DEV_GETTING_STARTED to include OpenAI as a supported direct provider.
  - Added `docs/MODEL_PROVIDER_COMPLIANCE.md` documenting the current model access matrix and how provider filtering is kept in sync with code/tests.

- **Settings UI & state**
  - Added OpenAI API key support to `SettingsPage` and `settingsStore`.
  - Replaced static model dropdown with provider-scoped model options via `src/services/llm/models.ts`.
  - Added model picker grouping/labeling per provider and a provider-specific access description under the model selector.
  - When switching providers, the model query is cleared and the selected model is normalized to a provider-allowed default if needed.

- **LLM provider routing**
  - Added a new `src/services/llm/openai.ts` client implementation.
  - Updated `src/services/llm/index.ts` to route completions/keys to OpenAI when selected.

- **Model registry & normalization**
  - Introduced `src/services/llm/models.ts`:
    - Provider registry with allowed models and display ordering per provider
    - Label helpers (`getProviderLabel`, `getModelLabel`)
    - Provider/model normalization and fallback behavior

- **Request shaping for GPT-5 reasoning**
  - Updated `chatCompletionBody` to set `reasoning_effort` for GPT-5 family models based on normalized model id.

- **Shared streaming compatibility**
  - Added `src/services/llm/streaming.ts` to unify:
    - `parseSSEStream` SSE parsing
    - `getCompletionText` extraction across multiple provider response shapes
  - Refactored OpenRouter and Cerebras clients to use the shared streaming utilities.
  - Added `src/services/llm/streaming.test.ts` for parsing/text extraction coverage.

- **History UI**
  - Updated history detail dialog metadata header to display a friendly provider label (OpenRouter/Cerebras/OpenAI).

- **Tests & package metadata**
  - Added `src/services/llm/models.test.ts` validating provider model lists, ordering, and normalization/fallback.
  - Added `packageManager` field to `package.json`.

## Testing
### Tested completions using OpenAI models 
### Tested completions using Llama on OpenRouter and Cerebras (still works as expected)

- Added/ran unit tests:
  - `src/services/llm/models.test.ts` for provider model registry filtering, ordering, and fallback behavior.
  - `src/services/llm/streaming.test.ts` for SSE streaming parsing and completion text extraction.
- Verified client routing paths for direct mode (OpenRouter/Cerebras/OpenAI) via the updated provider/model selection logic and normalization in settings state.