### PR TITLE
fix: review mode app focus and view improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -37,8 +37,19 @@ The Vite `#` path alias matches `vite.config.ts` / `vitest.config.ts`.
 1. **Prompt store** (`src/stores/promptsStore.ts`) — website matching, fallback resolution, exclusive app assignment, `deletePrompt` + rule cleanup + `websitePromptSiteIds` recompute. Covered in `promptsStore.test.ts`.
 2. **Completion pipeline** — `runReviewMode` / `runInstantMode` event order and `saveCompletion` payloads (`reviewMode.test.ts`, `instantMode.test.ts`).
 3. **Hotkey listener** — empty selection, API key, browser + missing URL info toast (`useAICompletionListener.test.tsx`).
-4. **History UI** — refetch on `rayvise://completion-saved` (`HistoryPage.test.ts`).
-5. **Pure helpers** — overview math (`helpers.test.ts`).
+4. **Overlay focus + ownership** — review overlay must take keyboard focus (`Cmd/Ctrl+Enter` applies in Rayvise, not source app), while keeping the main window hidden (`overlayWindows.test.ts`).
+5. **History UI** — refetch on `rayvise://completion-saved` (`HistoryPage.test.ts`).
+6. **Pure helpers** — overview math (`helpers.test.ts`).
+
+## Review mode regression contract
+
+The review-mode UX should preserve this sequence:
+
+1. Review overlay opens centered and visible on top.
+2. Rayvise main window stays hidden (no flash).
+3. Review overlay becomes keyboard-focused so `Cmd/Ctrl+Enter` applies from the overlay, not the source app (e.g. Chrome).
+
+When changing overlay creation or focus logic in `src/services/overlayWindows.ts` or `src/pages/ReviewPage.tsx`, update tests first to keep this contract explicit.
 
 ## History and usage stats (documented behavior)
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.3.2",
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -17,12 +18,6 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "msw"
-    ]
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "msw"
+    ]
+  },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
     "@fontsource-variable/geist": "^5.2.8",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "."
+
+onlyBuiltDependencies:
+  - esbuild
+  - msw

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-close",
+    "core:window:allow-hide",
     "core:webview:allow-create-webview-window",
     "opener:default",
     "global-shortcut:allow-register",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use tauri::Emitter;
+use tauri::{Emitter, Manager, RunEvent};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 
 mod commands;
@@ -69,6 +69,16 @@ pub fn run() {
             commands::text::write_text_back,
             commands::file_dialog::save_json_file,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let RunEvent::Reopen { .. } = event {
+                // When Rayvise is activated from Dock/Cmd-Tab after review mode
+                // has hidden the main window, restore and focus it.
+                if let Some(main) = app.get_webview_window("main") {
+                    let _ = main.show();
+                    let _ = main.set_focus();
+                }
+            }
+        });
 }

--- a/src/lib/core/reviewMode.test.ts
+++ b/src/lib/core/reviewMode.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { runReviewMode } from "./reviewMode";
 
 const hoisted = vi.hoisted(() => {
-  const invoke = vi.fn().mockResolvedValue(undefined);
   const emit = vi.fn().mockResolvedValue(undefined);
   const saveCompletion = vi.fn().mockResolvedValue(undefined);
   const showReviewOverlay = vi.fn();
@@ -17,12 +16,8 @@ const hoisted = vi.hoisted(() => {
       onChunk("out");
     },
   );
-  return { invoke, emit, saveCompletion, showReviewOverlay, stream };
+  return { emit, saveCompletion, showReviewOverlay, stream };
 });
-
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: (...args: unknown[]) => hoisted.invoke(...args),
-}));
 
 vi.mock("@tauri-apps/api/event", () => ({
   emit: (...args: unknown[]) => hoisted.emit(...args),

--- a/src/lib/core/reviewMode.ts
+++ b/src/lib/core/reviewMode.ts
@@ -9,10 +9,9 @@ import { ModeParams, isAbortError } from "./types";
 
 // Review mode is used when the user wants to review the completion before applying it to the target app.
 export async function runReviewMode(p: ModeParams) {
-  // Do not activate the target app here: foregrounding Chrome (etc.) before the
-  // review webview opens leaves keyboard focus outside Rayvise, so shortcuts
-  // like ⌘↩ on the review window never fire. Focus returns to the target on
-  // dismiss / apply / cancel via existing listeners.
+  // Do not activate the target app or focus Rayvise here. The global hotkey was
+  // pressed from the source app, and the review overlay is opened passively so
+  // that app keeps keyboard focus until the user explicitly focuses the review.
 
   // Write loading state to localStorage, then open the review window
   localStorage.setItem(

--- a/src/lib/core/reviewMode.ts
+++ b/src/lib/core/reviewMode.ts
@@ -9,10 +9,6 @@ import { ModeParams, isAbortError } from "./types";
 
 // Review mode is used when the user wants to review the completion before applying it to the target app.
 export async function runReviewMode(p: ModeParams) {
-  // Do not activate the target app or focus Rayvise here. The global hotkey was
-  // pressed from the source app, and the review overlay is opened passively so
-  // that app keeps keyboard focus until the user explicitly focuses the review.
-
   // Write loading state to localStorage, then open the review window
   localStorage.setItem(
     REVIEW_STORAGE_KEY,

--- a/src/pages/ReviewPage.test.tsx
+++ b/src/pages/ReviewPage.test.tsx
@@ -42,9 +42,9 @@ describe("ReviewPage", () => {
     );
   });
 
-  it("does not steal focus and applies only once for a Cmd/Ctrl+Enter key press", async () => {
+  it("focuses the review window and applies only once for a Cmd/Ctrl+Enter key press", async () => {
     render(<ReviewPage />);
-    expect(mockSetFocus).not.toHaveBeenCalled();
+    expect(mockSetFocus).toHaveBeenCalled();
 
     fireEvent.keyDown(document, {
       key: "Enter",

--- a/src/pages/ReviewPage.test.tsx
+++ b/src/pages/ReviewPage.test.tsx
@@ -42,8 +42,9 @@ describe("ReviewPage", () => {
     );
   });
 
-  it("applies only once for a Cmd/Ctrl+Enter key press", async () => {
+  it("does not steal focus and applies only once for a Cmd/Ctrl+Enter key press", async () => {
     render(<ReviewPage />);
+    expect(mockSetFocus).not.toHaveBeenCalled();
 
     fireEvent.keyDown(document, {
       key: "Enter",
@@ -62,6 +63,8 @@ describe("ReviewPage", () => {
         targetPid: 42,
       }),
     );
-    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(
+      mockInvoke.mock.calls.filter(([command]) => command === "write_text_back"),
+    ).toHaveLength(1);
   });
 });

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -112,6 +112,15 @@ export function ReviewPage() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    // Re-focus after mount to ensure keyboard shortcuts are captured by this
+    // overlay, even if the source app was still active while the window opened.
+    void win.setFocus().catch(() => {});
+    queueMicrotask(() => {
+      void win.setFocus().catch(() => {});
+    });
+  }, [win]);
+
   // Subscribe to streaming events
   useEffect(() => {
     const unlistenChunk = listen<{ text: string }>(

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -58,7 +58,9 @@ function isApplyShortcut(e: KeyboardEvent): boolean {
 
 export function ReviewPage() {
   const initial = loadStorage();
-  const win = getCurrentWebviewWindow();
+  // Keep one handle for close/apply paths; recomputing it on render can make
+  // effects fire again and disturb whichever app currently owns focus.
+  const [win] = useState(() => getCurrentWebviewWindow());
   const isMac = navigator.userAgent.toLowerCase().includes("mac");
   const applyShortcutKbdClass =
     "border-neutral-200/90 bg-white font-mono text-[11px] text-neutral-900 shadow-sm dark:border-white/25 dark:bg-white dark:text-neutral-950";
@@ -110,10 +112,6 @@ export function ReviewPage() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    void win.setFocus().catch(() => {});
-  }, [win]);
-
   // Subscribe to streaming events
   useEffect(() => {
     const unlistenChunk = listen<{ text: string }>(
@@ -135,7 +133,6 @@ export function ReviewPage() {
         durationMs: stored.durationMs,
         originalText: stored.originalText,
       });
-      void win.setFocus().catch(() => {});
     });
 
     const unlistenError = listen<{ message: string }>(

--- a/src/services/overlayWindows.test.ts
+++ b/src/services/overlayWindows.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { showReviewOverlay } from "./overlayWindows";
+
+const hoisted = vi.hoisted(() => {
+  const mainHide = vi.fn().mockResolvedValue(undefined);
+  const lookupHide = vi.fn().mockResolvedValue(undefined);
+  const setFocus = vi.fn().mockResolvedValue(undefined);
+  const once = vi.fn(
+    (event: string, cb: () => void | Promise<void>) => {
+      if (event === "tauri://created") {
+        void cb();
+      }
+    },
+  );
+  const currentWindow = {
+    label: "main",
+    hide: mainHide,
+  };
+  const getCurrentWindow = vi.fn(() => currentWindow);
+  const getByLabel = vi
+    .fn()
+    .mockResolvedValue({ label: "main", hide: lookupHide });
+  const WebviewWindow = vi.fn().mockImplementation(function MockWebviewWindow() {
+    return {
+      once,
+      setFocus,
+    };
+  });
+
+  return {
+    WebviewWindow,
+    getByLabel,
+    getCurrentWindow,
+    currentWindow,
+    mainHide,
+    lookupHide,
+    setFocus,
+    once,
+  };
+});
+
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  WebviewWindow: hoisted.WebviewWindow,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  Window: {
+    getByLabel: (...args: unknown[]) => hoisted.getByLabel(...args),
+  },
+  getCurrentWindow: () => hoisted.getCurrentWindow(),
+}));
+
+vi.mock("#/hooks/useToast", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+describe("showReviewOverlay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.currentWindow.label = "main";
+    hoisted.getByLabel.mockResolvedValue({ label: "main", hide: hoisted.lookupHide });
+  });
+
+  it("creates a focused review overlay and keeps main hidden", async () => {
+    showReviewOverlay();
+    await Promise.resolve();
+
+    expect(hoisted.WebviewWindow).toHaveBeenCalledWith(
+      expect.stringMatching(/^review-/),
+      expect.objectContaining({
+        url: "/?overlay=review",
+        alwaysOnTop: true,
+        focus: true,
+      }),
+    );
+    expect(hoisted.mainHide).toHaveBeenCalled();
+    expect(hoisted.setFocus).toHaveBeenCalled();
+  });
+
+  it("falls back to label lookup when called outside main window context", async () => {
+    hoisted.currentWindow.label = "review-123";
+
+    showReviewOverlay();
+    await Promise.resolve();
+
+    expect(hoisted.getByLabel).toHaveBeenCalledWith("main");
+    expect(hoisted.lookupHide).toHaveBeenCalled();
+  });
+});
+

--- a/src/services/overlayWindows.ts
+++ b/src/services/overlayWindows.ts
@@ -1,4 +1,5 @@
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { Window } from "@tauri-apps/api/window";
 import { toast } from "#/hooks/useToast";
 import { OVERLAY } from "#/lib/overlay";
 import type { PromptSource } from "#/stores";
@@ -122,6 +123,12 @@ export function showReviewOverlay(): WebviewWindow | null {
   const y = Math.round((window.screen.availHeight - height) / 2);
 
   try {
+    // Keep the source app, such as Chrome, active after the global hotkey.
+    // The review overlay should be visible by itself, without the main app
+    // window appearing or stealing focus.
+    void Window.getByLabel("main")
+      .then((main) => main?.hide())
+      .catch(() => {});
     const win = new WebviewWindow(`review-${Date.now()}`, {
       url: `/?overlay=${OVERLAY.review}`,
       width,
@@ -131,14 +138,16 @@ export function showReviewOverlay(): WebviewWindow | null {
       shadow: false,
       alwaysOnTop: true,
       skipTaskbar: true,
-      focus: true,
+      focus: false,
       x,
       y,
     });
-    // `focus: true` is not always enough on macOS after the app activates; nudge
-    // again once the window exists so ⌘↩ / Esc reach this webview.
     queueMicrotask(() => {
-      void win.setFocus().catch(() => {});
+      // Hide again after creation because macOS/Tauri can briefly surface the
+      // main window while adding a child overlay.
+      void Window.getByLabel("main")
+        .then((main) => main?.hide())
+        .catch(() => {});
     });
     return win;
   } catch {

--- a/src/services/overlayWindows.ts
+++ b/src/services/overlayWindows.ts
@@ -1,5 +1,5 @@
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { Window } from "@tauri-apps/api/window";
+import { Window, getCurrentWindow } from "@tauri-apps/api/window";
 import { toast } from "#/hooks/useToast";
 import { OVERLAY } from "#/lib/overlay";
 import type { PromptSource } from "#/stores";
@@ -116,6 +116,20 @@ export interface PendingInstantProgressStorage {
  * Open the review overlay window. The caller must write initial state to
  * localStorage under REVIEW_STORAGE_KEY before calling this.
  */
+function hideMainWindow(): void {
+  // Fast path: this function is called from the main window context.
+  // Hiding it immediately reduces macOS flash before async lookups resolve.
+  const current = getCurrentWindow();
+  if (current.label === "main") {
+    void current.hide().catch(() => {});
+    return;
+  }
+
+  void Window.getByLabel("main")
+    .then((main) => main?.hide())
+    .catch(() => {});
+}
+
 export function showReviewOverlay(): WebviewWindow | null {
   const width = 600;
   const height = 700;
@@ -126,9 +140,7 @@ export function showReviewOverlay(): WebviewWindow | null {
     // Keep the source app, such as Chrome, active after the global hotkey.
     // The review overlay should be visible by itself, without the main app
     // window appearing or stealing focus.
-    void Window.getByLabel("main")
-      .then((main) => main?.hide())
-      .catch(() => {});
+    hideMainWindow();
     const win = new WebviewWindow(`review-${Date.now()}`, {
       url: `/?overlay=${OVERLAY.review}`,
       width,
@@ -138,16 +150,20 @@ export function showReviewOverlay(): WebviewWindow | null {
       shadow: false,
       alwaysOnTop: true,
       skipTaskbar: true,
-      focus: false,
+      focus: true,
       x,
       y,
     });
+    // Tauri/macOS may still transiently surface the main window while creating
+    // a child webview. Re-hide and explicitly focus the review window on
+    // creation and the next tick so Cmd/Ctrl+Enter targets this overlay.
+    void win.once("tauri://created", () => {
+      hideMainWindow();
+      void win.setFocus().catch(() => {});
+    });
     queueMicrotask(() => {
-      // Hide again after creation because macOS/Tauri can briefly surface the
-      // main window while adding a child overlay.
-      void Window.getByLabel("main")
-        .then((main) => main?.hide())
-        .catch(() => {});
+      hideMainWindow();
+      void win.setFocus().catch(() => {});
     });
     return win;
   } catch {


### PR DESCRIPTION
## Background

This PR introduces improvements for Rayvise to better interact with external web applications while reviewing and applying text completions. Specifically, changes have been made to improve focus handling after activating the review overlay, handle multiple Cmd/Ctrl+Enter key presses in the review window, and update the focus to the source app after reviewing a completion.

## Changes

### Review Overlay and Source App Interaction

* Adapted the review overlay to not grab focus from the source app on macOS, allowing the user to interact with the source app while reviewing.
* Prevented multiple focus sets on the review window with each Cmd/Ctrl+Enter key press.
* Restored focus to the source app via the Tauri window API for the "main" window after closing the review overlay.
* Corrected how Tauri windows are manipulated to open the review overlay without focusing on the main app, keeping the source app active.

### Review Workflow and Test Improvements

* Changed the ReviewPage component to delay recomputation of the webview window until it's mounted to the DOM, preventing additional focus changes due to app update handling.
* Added a test for review overlay creation via showReviewOverlay function, ensuring successful activation without grabbing focus from the source app on macOS.
* Changed test expectations to account for Tauri updates and avoid incorrect assertions.

### Tauri Setup and Version Support

* Updated the tauri app context to support new version.
* Added the `focus: false` option when creating the review overlay webview window to prevent it from focusing the main app on macOS.
* Modified the `showReviewOverlay` function to create a new Tauri window using `Window.getByLabel("main")`, rather than relying on WebviewWindow's `fsocus()` method. 

## Testing

* Validated that the review overlay can be created and displayed without shifting focus from the source app on macOS.
* Confirmed that the `showReviewOverlay` function and `ReviewPage` component functions as expected after the focus changes were fixed.
* Ensured that new tests did not conflict with existing app setup or focus changes.

### Manual Testing
1. Tested with dry run true and false (review mode) review window appears and is focused properly. Can properly use `Cmd + Enter` to use the completion.