### PR TITLE
feat: local llm support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,17 @@ Zustand + `persist` (localStorage), all re-exported from `src/stores/index.ts`:
 
 - `VITE_DRY_RUN=true` → `dryRunClient` (highest priority; used by Vitest via `vitest.config.ts`)
 - `mode: "api"` → `rayviseApiClient` (throws — not yet implemented)
-- `mode: "direct"` → `cerebrasClient` or `openrouterClient`
+- `mode: "direct"` → `openrouterClient`, `cerebrasClient`, `openaiClient`, or `localClient`
 
 All clients implement `.stream(req, apiKey, onChunk, signal)` with `AbortSignal` support.
+
+**Local LLM provider:** `LLM_PROVIDER.Local` uses `src/services/llm/local.ts`, which calls Rust commands in `src-tauri/src/commands/local_llm.rs` instead of browser `fetch`. The Rust command validates loopback-only base URLs (`localhost`, `127.0.0.1`, `::1`), normalizes empty or `/v1` paths to `/v1/`, lists models through `/v1/models`, streams OpenAI-style SSE from `/v1/chat/completions`, and supports cancellation through `cancel_local_chat_completion`. Do not loosen the loopback-only policy without updating `docs/LOCAL_LLM.md` and the privacy wording.
+
+Local request bodies are still produced through `chatCompletionBody(LLM_PROVIDER.Local, ...)`; it maps Rayvise `instruction` messages to OpenAI-compatible `system` messages and sends `reasoning_effort: "none"` / `reasoning: { effort: "none" }`. `createThinkBlockStripper()` removes streamed `<think>...</think>` blocks before review/instant output and history save.
+
+Local settings live in `settingsStore`: `localBaseUrl`, `localApiKey`, `localModelOptions`, and `modelSelections`. Local accepts arbitrary non-empty model names because installed Ollama models vary by machine; external providers remain provider-whitelisted. The Local provider intentionally does not require an API key.
+
+For user/dev docs, see `docs/LOCAL_LLM.md`. It references official Ollama OpenAI compatibility docs and hardware constraints: Ollama's FAQ describes model loading, `ollama ps`, memory/VRAM, context, and concurrency behavior; Apple documents unified memory through Metal's `hasUnifiedMemory`; Ollama model-library pages show how model parameter count and download size differ. Keep Local documentation grounded in those external sources when changing this area.
 
 ### Database
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ For detailed compatibility information and contributor guidance on cross-platfor
 - **Review mode** — preview, stream, and edit AI output in real-time before accepting or rejecting
 - **Instant mode** — processing overlay shows live progress while text is being written back directly to your app
 - **Cancellation** — press Esc during processing to abort the current request
-- **Privacy-first direct mode** — for those wanting to keep data between you and your AI provider only, you can do so with direct-mode. Your prompt and input text goes straight to OpenRouter or Cerebras, never through Rayvise servers, and the output is returned only to your device
+- **Privacy-first direct mode** — for those wanting to keep data between you and your AI provider only, you can do so with direct-mode. Your prompt and input text goes straight to OpenRouter, Cerebras, OpenAI, or a loopback Local LLM endpoint, never through Rayvise servers, and the output is returned only to your device
+- **Local LLM support** — run against an Ollama-compatible local OpenAI endpoint with streaming, model discovery, optional token support, and reasoning-output suppression
 - **Prompt library** — create, edit, and manage reusable prompts for your needs
 - **History** - view your usage stats and past AI responses (inputs, outputs, prompt used, etc)
 
@@ -60,7 +61,7 @@ For detailed compatibility information and contributor guidance on cross-platfor
 | Frontend      | React 19 + TypeScript                    |
 | Styling       | Tailwind CSS v4                          |
 | State         | Zustand                                  |
-| LLM providers | OpenRouter, Cerebras, OpenAI             |
+| LLM providers | OpenRouter, Cerebras, OpenAI, Local      |
 
 ## Quick Start
 
@@ -75,16 +76,17 @@ For full setup instructions see the **[getting started guide](docs/DEV_GETTING_S
 
 ## LLM Providers
 
-Rayvise currently supports three **direct-to-provider** modes (your data never touches Rayvise servers):
+Rayvise supports cloud **direct-to-provider** modes and a local OpenAI-compatible provider (your data never touches Rayvise servers):
 
 - **[OpenRouter](https://openrouter.ai/)** — access to a wide range of models
   - [Models used by Rayvise users](https://openrouter.ai/apps?url=https%3A%2F%2Frayvise.com%2F) — see what models people are using with Rayvise through OpenRouter
 - **[Cerebras](https://www.cerebras.ai/)** — ultra-fast inference powered by their Wafer Scale Engine
   - [Cerebras Chips](https://www.cerebras.ai/chip) - read more about Cerebras hardware
 - **[OpenAI](https://platform.openai.com/)** — direct access to the GPT-5 and GPT-5.4 families in Rayvise
+- **Local** — connect to a loopback OpenAI-compatible endpoint such as Ollama at `http://localhost:11434/v1`
 
 Configure your API keys in the Rayvise app's Settings page (your API keys are stored on your device and do not pass through Rayvise's servers).
-The Settings page filters models by provider so users only see models allowed for that direct connection. See **[docs/MODEL_PROVIDER_COMPLIANCE.md](docs/MODEL_PROVIDER_COMPLIANCE.md)** for how provider-scoped filtering and normalization work.
+The Settings page filters models by provider so users only see models allowed for that direct connection; Local also supports manually typed model names because installed local models vary by machine. See **[docs/MODEL_PROVIDER_COMPLIANCE.md](docs/MODEL_PROVIDER_COMPLIANCE.md)** for provider-scoped filtering and normalization, and **[docs/LOCAL_LLM.md](docs/LOCAL_LLM.md)** for Local/Ollama setup, implementation notes, and Apple Silicon hardware constraints.
 
 ## Contributing
 

--- a/docs/DEV_GETTING_STARTED.md
+++ b/docs/DEV_GETTING_STARTED.md
@@ -37,11 +37,28 @@ You can configure your options in the app settings.
 
 ### Direct to Provider
 
-You can set one or more of [OpenRouter](https://openrouter.ai/), [Cerebras](https://www.cerebras.ai/), or [OpenAI](https://platform.openai.com/) API keys and select which one you want to route your requests through.
+You can set one or more of [OpenRouter](https://openrouter.ai/), [Cerebras](https://www.cerebras.ai/), or [OpenAI](https://platform.openai.com/) API keys and select which one you want to route your requests through. You can also choose **Local** to route requests to run LLMs locally on a loopback OpenAI-compatible server like [Ollama](https://ollama.com/).
 
-**(Privacy-first):** Your prompt, inputs, and outputs do not pass through Rayvise's servers and are not stored anywhere in our database. Your request goes from the app to the provider you selected and returns directly back to you. Please review each provider's privacy policies on how they will interact with your personal/business data.
+**(BYOK Privacy-first option):** Your prompt, inputs, and outputs do not pass through Rayvise's servers and thus are not stored anywhere in our database. Your request goes from the app to the provider you selected and returns directly back to you. Please review each provider's privacy policies on how they will interact with your personal/business data.
 
 Rayvise filters the model picker by provider so only models allowed for that direct connection are shown. See [MODEL_PROVIDER_COMPLIANCE.md](MODEL_PROVIDER_COMPLIANCE.md) for the filtering and normalization rules.
+
+### Running Rayvise with a Local LLM
+
+The Local provider defaults to Ollama's OpenAI-compatible endpoint:
+
+You can download the model weights and then run rayvise by running:
+
+```bash
+ollama pull llama3.2
+pnpm tauri dev
+```
+
+Then open Rayvise Settings, select **Direct to Provider** → **Local**, keep `http://localhost:11434/v1`, and click **Refresh models**. Ollama documents this OpenAI-compatible base URL, `/v1/chat/completions`, streaming support, `/v1/models`, and the ignored API-key convention in its [OpenAI compatibility docs](https://docs.ollama.com/openai).
+
+For implementation details, local endpoint validation, reasoning-output handling, and hardware guidance, see [LOCAL_LLM.md](LOCAL_LLM.md).
+
+Local model performance depends heavily on memory. On Apple Silicon, CPU and GPU share unified memory, so available RAM and model size are usually the practical bottleneck. Ollama's FAQ documents how loaded models use system memory or VRAM, how `ollama ps` reports loaded model size/processor placement, and how context/concurrency settings increase memory use. Apple documents unified-memory behavior in Metal's [`MTLDevice.hasUnifiedMemory`](https://developer.apple.com/documentation/metal/mtldevice/hasunifiedmemory), and Ollama model-library pages such as [Llama 3.2](https://ollama.com/library/llama3.2) and [Qwen3](https://ollama.com/library/qwen3) show how parameter count and model download size vary.
 
 ### Rayvise API
 

--- a/docs/LOCAL_LLM.md
+++ b/docs/LOCAL_LLM.md
@@ -1,0 +1,86 @@
+# Local LLM Integration
+
+Rayvise supports a **Local** direct provider for Ollama-compatible OpenAI APIs. This lets the app send completion requests to a loopback LLM server instead of an external provider.
+
+## What Rayvise Calls
+
+Rayvise's Local provider is designed around Ollama's OpenAI-compatible API:
+
+- Default base URL: `http://localhost:11434/v1`
+- Chat streaming endpoint: `POST /v1/chat/completions`
+- Model discovery endpoint: `GET /v1/models`
+- Default model name: `llama3.2`
+
+Ollama documents the OpenAI-compatible base URL as `http://localhost:11434/v1/`, notes that OpenAI client API keys are required by some tooling but ignored by Ollama, supports streaming chat completions, exposes `/v1/models`, and supports reasoning controls such as `reasoning_effort: "none"` for thinking models. See the official [Ollama OpenAI compatibility docs](https://docs.ollama.com/openai) and [Ollama API OpenAI compatibility docs](https://docs.ollama.com/api/openai-compatibility).
+
+Rayvise sends Local requests through Rust commands instead of browser `fetch` so the desktop app can:
+
+- avoid webview CSP/CORS surprises for local servers;
+- enforce loopback-only URLs before any request is sent;
+- stream chunks back into the existing review and instant-mode pipelines;
+- cancel in-flight requests through the same `AbortSignal` path used by external providers.
+
+## Setup
+
+1. Install Ollama from the official [Ollama download page](https://ollama.com/download).
+2. Pull a local model:
+
+   ```bash
+   ollama pull llama3.2
+   ```
+
+3. Start Rayvise with `pnpm tauri dev`.
+4. Open Settings, choose **Direct to Provider**, then choose **Local**.
+5. Leave the base URL as `http://localhost:11434/v1` for default Ollama.
+6. Leave the optional token blank for Ollama.
+7. Click **Refresh models** or type a model name manually.
+
+Rayvise does not install Ollama, launch the Ollama server, or pull models. It only connects to an already-running local OpenAI-compatible endpoint.
+
+## Security Boundary
+
+Local provider URLs are intentionally restricted to loopback hosts:
+
+- `localhost`
+- `127.0.0.1`
+- `::1`
+
+The Rust validator rejects non-HTTP(S) schemes, credentials in the URL, non-loopback hosts, and paths other than empty or `/v1`. This keeps the Local provider aligned with the "fully local LLM call" promise and prevents the Local setting from silently becoming an arbitrary remote network client.
+
+The privacy boundary is specific to LLM calls and model discovery. Other Rayvise features keep their existing behavior.
+
+## Reasoning Output
+
+Rayvise suppresses reasoning output for Local completions by default:
+
+- request bodies include `reasoning_effort: "none"` and `reasoning: { "effort": "none" }`;
+- streamed `<think>...</think>` blocks are stripped before review display, instant writeback, and history save.
+
+This is intentional because Rayvise writes model output into user-selected app text. Hidden reasoning from thinking models should not leak into the replacement text.
+
+## Hardware Constraints
+
+Local inference is constrained by memory capacity and model size.
+
+Apple Silicon Macs use unified memory, meaning the GPU can share memory with the CPU. Apple's Metal documentation describes `hasUnifiedMemory` as indicating that the GPU shares all of its memory with the CPU, and Apple Mac technical specs list unified-memory capacities and memory bandwidth for Apple Silicon models. See Apple Developer's [`MTLDevice.hasUnifiedMemory`](https://developer.apple.com/documentation/metal/mtldevice/hasunifiedmemory) and Apple Support's [MacBook Air M4 tech specs](https://support.apple.com/en-us/122209) or [Mac Studio 2025 tech specs](https://support.apple.com/en-us/122211).
+
+That unified memory pool is still finite. Running a local model competes with macOS, Rayvise, the target app, browser tabs, and any other workloads. Larger models and larger context windows use more memory:
+
+- Ollama's FAQ explains that model loading and concurrency depend on available system memory or VRAM, and that parallel requests multiply context allocation through `OLLAMA_NUM_PARALLEL * OLLAMA_CONTEXT_LENGTH`.
+- Ollama's FAQ also recommends `ollama ps` to inspect loaded model size and whether a model is running on CPU, GPU, or split CPU/GPU.
+- The Ollama model library shows concrete model-size differences: `llama3.2` defaults to a 3B model around 2.0GB, while Qwen3 variants range from small sub-1GB models to 14B/30B/235B variants listed at much larger download sizes.
+
+Start with small models on low-memory machines:
+
+```bash
+ollama pull llama3.2:1b
+ollama pull llama3.2
+```
+
+Use `ollama ps` while Rayvise is making requests to see what is loaded and where. If completions are slow, fail to load, or cause memory pressure, choose a smaller model, reduce context size in Ollama, stop other memory-heavy apps, or run on a Mac with more unified memory.
+
+References:
+
+- [Ollama FAQ: memory, `ollama ps`, context, and concurrency](https://docs.ollama.com/faq)
+- [Ollama Llama 3.2 model library](https://ollama.com/library/llama3.2)
+- [Ollama Qwen3 model library](https://ollama.com/library/qwen3)

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -248,11 +248,9 @@ fn icns_to_png_via_iconutil(
     let mut copied = false;
     for name in &candidates {
         let src = iconset_dir.join(name);
-        if src.exists() {
-            if std::fs::copy(&src, output_path).is_ok() {
-                copied = true;
-                break;
-            }
+        if src.exists() && std::fs::copy(&src, output_path).is_ok() {
+            copied = true;
+            break;
         }
     }
 

--- a/src-tauri/src/commands/local_llm.rs
+++ b/src-tauri/src/commands/local_llm.rs
@@ -1,0 +1,371 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::sync::Mutex;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, State};
+use url::{Host, Url};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Default)]
+pub struct LocalLlmState {
+    canceled_sessions: Mutex<HashSet<String>>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalStreamChunk {
+    session_id: String,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelsResponse {
+    data: Option<Vec<ModelEntry>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelEntry {
+    id: Option<String>,
+}
+
+fn normalize_local_base_url(raw: &str) -> Result<Url, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("Local base URL is required.".to_string());
+    }
+
+    let mut url = Url::parse(trimmed).map_err(|_| "Invalid Local base URL.".to_string())?;
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return Err("Local base URL must use http or https.".to_string());
+    }
+
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("Local base URL cannot contain credentials.".to_string());
+    }
+
+    let is_loopback = match url.host() {
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    };
+    if !is_loopback {
+        return Err("Local base URL must point to localhost, 127.0.0.1, or ::1.".to_string());
+    }
+
+    let path = url.path().trim_end_matches('/');
+    match path {
+        "" | "/" => url.set_path("/v1/"),
+        "/v1" => url.set_path("/v1/"),
+        _ => return Err("Local base URL path must be /v1 or empty.".to_string()),
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+
+    Ok(url)
+}
+
+fn endpoint(base_url: &Url, path: &str) -> Result<Url, String> {
+    base_url
+        .join(path)
+        .map_err(|_| "Invalid Local endpoint URL.".to_string())
+}
+
+fn client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .user_agent("Rayvise/0.3")
+        .build()
+        .map_err(|err| format!("Could not create Local client: {err}"))
+}
+
+fn with_auth(builder: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBuilder {
+    let token = api_key.trim();
+    if token.is_empty() {
+        builder
+    } else {
+        builder.bearer_auth(token)
+    }
+}
+
+fn session_is_canceled(
+    state: &State<'_, LocalLlmState>,
+    session_id: &str,
+) -> Result<bool, String> {
+    state
+        .canceled_sessions
+        .lock()
+        .map(|sessions| sessions.contains(session_id))
+        .map_err(|_| "Could not read Local provider cancellation state.".to_string())
+}
+
+fn cleanup_session(state: &State<'_, LocalLlmState>, session_id: &str) {
+    if let Ok(mut sessions) = state.canceled_sessions.lock() {
+        sessions.remove(session_id);
+    }
+}
+
+fn extract_content_text(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Array(items) => items
+            .iter()
+            .map(extract_content_text)
+            .collect::<Vec<_>>()
+            .join(""),
+        Value::Object(record) => ["text", "content", "output_text", "value"]
+            .iter()
+            .filter_map(|key| record.get(*key))
+            .map(extract_content_text)
+            .collect::<Vec<_>>()
+            .join(""),
+        _ => String::new(),
+    }
+}
+
+fn parse_sse_chunk(raw: &str) -> Result<Vec<String>, String> {
+    let payload: Value =
+        serde_json::from_str(raw).map_err(|_| "Invalid stream JSON.".to_string())?;
+    if let Some(message) = payload
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+    {
+        return Err(message.to_string());
+    }
+
+    let mut chunks = Vec::new();
+    if let Some(choices) = payload.get("choices").and_then(Value::as_array) {
+        for choice in choices {
+            if choice
+                .get("finish_reason")
+                .and_then(Value::as_str)
+                .is_some_and(|reason| reason == "error")
+            {
+                return Err("stream terminated with an error".to_string());
+            }
+
+            let content = choice
+                .get("delta")
+                .and_then(|delta| delta.get("content"))
+                .or_else(|| {
+                    choice
+                        .get("message")
+                        .and_then(|message| message.get("content"))
+                })
+                .map(extract_content_text)
+                .unwrap_or_default();
+
+            if !content.is_empty() {
+                chunks.push(content);
+            }
+        }
+    }
+
+    Ok(chunks)
+}
+
+fn parse_models_response(response: ModelsResponse) -> Vec<String> {
+    response
+        .data
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|entry| entry.id.map(|id| id.trim().to_string()))
+        .filter(|id| !id.is_empty())
+        .collect()
+}
+
+async fn stream_local_chat_completion_inner(
+    app: AppHandle,
+    state: State<'_, LocalLlmState>,
+    session_id: String,
+    base_url: String,
+    api_key: String,
+    body: Value,
+) -> Result<(), String> {
+    let base_url = normalize_local_base_url(&base_url)?;
+    let url = endpoint(&base_url, "chat/completions")?;
+    let client = client()?;
+    let body = serde_json::to_vec(&body)
+        .map_err(|err| format!("Could not serialize Local request: {err}"))?;
+    let request = with_auth(client.post(url), &api_key)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body);
+    let mut response = request
+        .send()
+        .await
+        .map_err(|err| format!("Local provider request failed: {err}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Local provider error: {}", response.status()));
+    }
+
+    let mut buffer = String::new();
+    while let Some(bytes) = response
+        .chunk()
+        .await
+        .map_err(|err| format!("Local provider stream failed: {err}"))?
+    {
+        if session_is_canceled(&state, &session_id)? {
+            return Err("Local provider request canceled.".to_string());
+        }
+
+        buffer.push_str(&String::from_utf8_lossy(&bytes));
+        let mut lines: Vec<String> = buffer.split('\n').map(str::to_string).collect();
+        buffer = lines.pop().unwrap_or_default().to_string();
+
+        for line in lines.drain(..) {
+            let line = line.trim_end_matches('\r');
+            if line.is_empty() || line.starts_with(':') || !line.starts_with("data:") {
+                continue;
+            }
+
+            let raw = line.trim_start_matches("data:").trim();
+            if raw == "[DONE]" {
+                return Ok(());
+            }
+
+            for text in parse_sse_chunk(raw)? {
+                app.emit(
+                    "rayvise://local-llm-stream",
+                    LocalStreamChunk {
+                        session_id: session_id.clone(),
+                        text,
+                    },
+                )
+                .map_err(|err| format!("Could not emit Local stream chunk: {err}"))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn list_local_models(base_url: String, api_key: String) -> Result<Vec<String>, String> {
+    let base_url = normalize_local_base_url(&base_url)?;
+    let url = endpoint(&base_url, "models")?;
+    let response = with_auth(client()?.get(url), &api_key)
+        .send()
+        .await
+        .map_err(|err| format!("Could not connect to Local provider: {err}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Local provider error: {}", response.status()));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|err| format!("Could not read Local models: {err}"))?;
+    let models = serde_json::from_slice::<ModelsResponse>(&bytes)
+        .map_err(|err| format!("Could not parse Local models: {err}"))?;
+
+    Ok(parse_models_response(models))
+}
+
+#[tauri::command]
+pub async fn cancel_local_chat_completion(
+    state: State<'_, LocalLlmState>,
+    session_id: String,
+) -> Result<(), String> {
+    state
+        .canceled_sessions
+        .lock()
+        .map_err(|_| "Could not cancel Local provider request.".to_string())?
+        .insert(session_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stream_local_chat_completion(
+    app: AppHandle,
+    state: State<'_, LocalLlmState>,
+    session_id: String,
+    base_url: String,
+    api_key: String,
+    body: Value,
+) -> Result<(), String> {
+    cleanup_session(&state, &session_id);
+    let result = stream_local_chat_completion_inner(
+        app,
+        state.clone(),
+        session_id.clone(),
+        base_url,
+        api_key,
+        body,
+    )
+    .await;
+    cleanup_session(&state, &session_id);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_local_base_url_accepts_loopback_v1() {
+        assert_eq!(
+            normalize_local_base_url("http://localhost:11434")
+                .unwrap()
+                .as_str(),
+            "http://localhost:11434/v1/"
+        );
+        assert_eq!(
+            normalize_local_base_url("http://127.0.0.1:11434/v1")
+                .unwrap()
+                .as_str(),
+            "http://127.0.0.1:11434/v1/"
+        );
+        assert_eq!(
+            normalize_local_base_url("http://[::1]:11434/v1/")
+                .unwrap()
+                .as_str(),
+            "http://[::1]:11434/v1/"
+        );
+    }
+
+    #[test]
+    fn normalize_local_base_url_rejects_remote_and_credentials() {
+        assert!(normalize_local_base_url("https://example.com/v1").is_err());
+        assert!(normalize_local_base_url("http://192.168.1.10:11434/v1").is_err());
+        assert!(normalize_local_base_url("ftp://localhost:11434/v1").is_err());
+        assert!(normalize_local_base_url("http://user:pass@localhost:11434/v1").is_err());
+        assert!(normalize_local_base_url("http://localhost:11434/other").is_err());
+    }
+
+    #[test]
+    fn parse_models_response_extracts_ids() {
+        let models = parse_models_response(ModelsResponse {
+            data: Some(vec![
+                ModelEntry {
+                    id: Some("llama3.2".to_string()),
+                },
+                ModelEntry {
+                    id: Some(" ".to_string()),
+                },
+                ModelEntry { id: None },
+            ]),
+        });
+
+        assert_eq!(models, vec!["llama3.2"]);
+    }
+
+    #[test]
+    fn parse_sse_chunk_extracts_content_and_errors() {
+        let chunks = parse_sse_chunk(r#"{"choices":[{"delta":{"content":"hello"}}]}"#).unwrap();
+        assert_eq!(chunks, vec!["hello"]);
+
+        let done_with_message =
+            parse_sse_chunk(r#"{"choices":[{"message":{"content":"done"}}]}"#).unwrap();
+        assert_eq!(done_with_message, vec!["done"]);
+
+        assert_eq!(
+            parse_sse_chunk(r#"{"error":{"message":"bad model"}}"#).unwrap_err(),
+            "bad model"
+        );
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod apps;
 pub mod browser_url;
 pub mod file_dialog;
 pub mod focused_app;
+pub mod local_llm;
 pub mod text;
 pub mod website_icons;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ struct HotkeyPayload {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .manage(commands::local_llm::LocalLlmState::default())
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(
@@ -68,6 +69,9 @@ pub fn run() {
             commands::text::get_selected_text,
             commands::text::write_text_back,
             commands::file_dialog::save_json_file,
+            commands::local_llm::list_local_models,
+            commands::local_llm::cancel_local_chat_completion,
+            commands::local_llm::stream_local_chat_completion,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/hooks/useAICompletionListener.test.tsx
+++ b/src/hooks/useAICompletionListener.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useAICompletionListener } from "./useAICompletionListener";
 import { usePromptsStore, useSettingsStore } from "#/stores";
-import { getApiKey } from "#/services/llm";
+import { getApiKey, providerRequiresApiKey } from "#/services/llm";
 import {
   showToastOverlay,
   PROMPT_PICK_STORAGE_KEY,
@@ -37,6 +37,7 @@ vi.mock("#/lib/core/instantMode", () => ({
 
 vi.mock("#/services/llm", () => ({
   getApiKey: vi.fn(() => "test-api-key"),
+  providerRequiresApiKey: vi.fn(() => true),
 }));
 
 vi.mock("#/services/overlayWindows", () => ({
@@ -197,6 +198,31 @@ describe("useAICompletionListener", () => {
       ),
     );
     expect(runInstantMode).not.toHaveBeenCalled();
+  });
+
+  it("does not require an API key for local provider completions", async () => {
+    vi.mocked(getApiKey).mockReturnValueOnce("");
+    vi.mocked(providerRequiresApiKey).mockReturnValueOnce(false);
+
+    renderHook(() => useAICompletionListener());
+
+    await waitFor(() =>
+      expect(listeners.has("rayvise://hotkey-triggered")).toBe(true),
+    );
+
+    listeners.get("rayvise://hotkey-triggered")!({
+      payload: {
+        app: "com.apple.Notes",
+        selected_text: "hello",
+        target_pid: 1,
+      },
+    });
+
+    await waitFor(() => expect(runInstantMode).toHaveBeenCalled());
+    expect(showToastOverlay).not.toHaveBeenCalledWith(
+      "No API key set. Go to Settings to add one.",
+      "error",
+    );
   });
 
   it("opens prompt picker when multiple app-mapped prompts match", async () => {

--- a/src/hooks/useAICompletionListener.ts
+++ b/src/hooks/useAICompletionListener.ts
@@ -6,7 +6,7 @@ import {
   useSettingsStore,
   type PromptResolution,
 } from "#/stores";
-import { getApiKey } from "#/services/llm";
+import { getApiKey, providerRequiresApiKey } from "#/services/llm";
 import {
   showToastOverlay,
   showPromptPickOverlay,
@@ -154,7 +154,7 @@ export function useAICompletionListener() {
         }
 
         const apiKey = getApiKey();
-        if (!apiKey) {
+        if (providerRequiresApiKey() && !apiKey) {
           showToastOverlay(
             "No API key set. Go to Settings to add one.",
             "error",
@@ -231,7 +231,7 @@ export function useAICompletionListener() {
         };
 
         const apiKey = getApiKey();
-        if (!apiKey) {
+        if (providerRequiresApiKey() && !apiKey) {
           showToastOverlay(
             "No API key set. Go to Settings to add one.",
             "error",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react";
-import { ChevronRight, Eye, EyeOff, Monitor, Moon, Sun } from "lucide-react";
+import {
+  ChevronRight,
+  Eye,
+  EyeOff,
+  Loader2,
+  Monitor,
+  Moon,
+  RefreshCw,
+  Sun,
+} from "lucide-react";
 import { ImportExportSection } from "./settings/ImportExportSection";
 import {
   Collapsible,
@@ -26,6 +35,7 @@ import {
   ComboboxLabel,
 } from "#/components/ui/combobox";
 import { Button } from "#/components/ui/button";
+import { listLocalModels } from "#/services/llm/local";
 import {
   DIRECT_PROVIDER_OPTIONS,
   getModelLabel,
@@ -41,6 +51,9 @@ export function SettingsPage() {
     openrouterApiKey,
     cerebrasApiKey,
     openaiApiKey,
+    localBaseUrl,
+    localApiKey,
+    localModelOptions,
     model,
     reviewMode,
     themeMode,
@@ -49,12 +62,27 @@ export function SettingsPage() {
     setOpenrouterApiKey,
     setCerebrasApiKey,
     setOpenaiApiKey,
+    setLocalBaseUrl,
+    setLocalApiKey,
+    setLocalModelOptions,
     setModel,
     setReviewMode,
     setThemeMode,
   } = useSettingsStore();
 
-  const modelOptions = getProviderModelOptions(provider);
+  const baseModelOptions = getProviderModelOptions(provider);
+  const modelOptions =
+    provider === LLM_PROVIDER.Local
+      ? Array.from(
+          new Set([
+            ...baseModelOptions.map((option) => option.value),
+            ...localModelOptions,
+            model,
+          ]),
+        )
+          .filter(Boolean)
+          .map((value) => ({ value, label: value }))
+      : baseModelOptions;
 
   const { prompts, defaultPromptId, setDefaultPrompt } = usePromptsStore();
   const { apps, hiddenAppBundleIds, unhideApp } = useAppsStore();
@@ -63,6 +91,10 @@ export function SettingsPage() {
   const [promptQuery, setPromptQuery] = useState("");
   const [modelQuery, setModelQuery] = useState("");
   const [hiddenAppsOpen, setHiddenAppsOpen] = useState(false);
+  const [localModelsLoading, setLocalModelsLoading] = useState(false);
+  const [localModelsMessage, setLocalModelsMessage] = useState<string | null>(
+    null,
+  );
   const promptSearch = useComboboxSearchDirty();
   const modelSearch = useComboboxSearchDirty();
   const hiddenApps = apps.filter((app) =>
@@ -91,13 +123,35 @@ export function SettingsPage() {
       ? cerebrasApiKey
       : provider === LLM_PROVIDER.OpenAI
         ? openaiApiKey
-        : openrouterApiKey;
+        : provider === LLM_PROVIDER.Local
+          ? localApiKey
+          : openrouterApiKey;
   const setCurrentKey =
     provider === LLM_PROVIDER.Cerebras
       ? setCerebrasApiKey
       : provider === LLM_PROVIDER.OpenAI
         ? setOpenaiApiKey
-        : setOpenrouterApiKey;
+        : provider === LLM_PROVIDER.Local
+          ? setLocalApiKey
+          : setOpenrouterApiKey;
+
+  const refreshLocalModels = async () => {
+    setLocalModelsLoading(true);
+    setLocalModelsMessage(null);
+    try {
+      const models = await listLocalModels(localBaseUrl, localApiKey);
+      setLocalModelOptions(models);
+      setLocalModelsMessage(
+        models.length === 0
+          ? "Connected, but no models were returned."
+          : `Found ${models.length} model${models.length === 1 ? "" : "s"}.`,
+      );
+    } catch (err) {
+      setLocalModelsMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLocalModelsLoading(false);
+    }
+  };
 
   const themeOptions: {
     value: ThemeMode;
@@ -183,7 +237,7 @@ export function SettingsPage() {
       {mode === "direct" && (
         <section className="space-y-3">
           <h2 className="text-foreground text-sm font-semibold">Provider</h2>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             {DIRECT_PROVIDER_OPTIONS.map((p) => (
               <Button
                 key={p}
@@ -208,7 +262,7 @@ export function SettingsPage() {
       )}
 
       {/* API Key */}
-      {mode === "direct" && (
+      {mode === "direct" && provider !== LLM_PROVIDER.Local && (
         <section className="space-y-2">
           <h2 className="text-foreground text-xs font-medium">
             {getProviderLabel(provider)} API Key
@@ -243,6 +297,84 @@ export function SettingsPage() {
               use Llama 3.1 8B or a paid tier to access that model.
             </p>
           ) : null}
+        </section>
+      )}
+
+      {mode === "direct" && provider === LLM_PROVIDER.Local && (
+        <section className="space-y-3">
+          <h2 className="text-foreground text-sm font-semibold">
+            Local Endpoint
+          </h2>
+          <div className="space-y-2">
+            <label className="text-foreground text-xs font-medium">
+              Base URL
+            </label>
+            <input
+              type="text"
+              value={localBaseUrl}
+              onChange={(e) => setLocalBaseUrl(e.target.value)}
+              placeholder="http://localhost:11434/v1"
+              className={cn(
+                "border-border bg-muted/30 text-foreground h-8 w-full rounded-lg border px-3 py-2 text-xs",
+                "placeholder:text-muted-foreground focus:border-ring focus:outline-none",
+              )}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-foreground text-xs font-medium">
+              Optional token
+            </label>
+            <div className="flex h-8 gap-2">
+              <input
+                type={showKey ? "text" : "password"}
+                value={currentKey}
+                onChange={(e) => setCurrentKey(e.target.value)}
+                placeholder="Leave blank for Ollama"
+                className={cn(
+                  "border-border bg-muted/30 text-foreground h-full flex-1 rounded-lg border px-3 py-2 text-xs",
+                  "placeholder:text-muted-foreground focus:border-ring focus:outline-none",
+                )}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowKey((v) => !v)}
+                className="border-border bg-muted/30 text-muted-foreground hover:text-foreground dark:hover:bg-input/45 dark:active:bg-input/55 h-full w-10 shrink-0"
+              >
+                {showKey ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={refreshLocalModels}
+              disabled={localModelsLoading}
+              className="gap-2"
+            >
+              {localModelsLoading ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RefreshCw className="size-4" />
+              )}
+              <span>Refresh models</span>
+            </Button>
+            {localModelsMessage ? (
+              <p className="text-muted-foreground text-xs">
+                {localModelsMessage}
+              </p>
+            ) : null}
+          </div>
+          <p className="text-muted-foreground text-xs">
+            Rayvise only allows loopback Local endpoints like localhost,
+            127.0.0.1, or ::1.
+          </p>
         </section>
       )}
 
@@ -297,7 +429,12 @@ export function SettingsPage() {
             if (id != null && id !== "") setModel(id);
           }}
           onOpenChange={modelSearch.onOpenChange}
-          onInputValueChange={(val) => setModelQuery(val)}
+          onInputValueChange={(val) => {
+            setModelQuery(val);
+            if (provider === LLM_PROVIDER.Local && val.trim()) {
+              setModel(val.trim());
+            }
+          }}
         >
           <ComboboxInput
             placeholder="Select a model..."

--- a/src/services/llm/chatCompletionBody.test.ts
+++ b/src/services/llm/chatCompletionBody.test.ts
@@ -36,6 +36,19 @@ describe("chatCompletionBody", () => {
     });
   });
 
+  it("serializes local requests with system instructions and reasoning suppression", () => {
+    expect(chatCompletionBody(LLM_PROVIDER.Local, request, true)).toEqual({
+      model: "gpt-5.4-mini",
+      messages: [
+        { role: "system", content: "Follow the prompt." },
+        { role: "user", content: "Hello" },
+      ],
+      stream: true,
+      reasoning_effort: "none",
+      reasoning: { effort: "none" },
+    });
+  });
+
   it("does not send dry-run metadata or reasoning_effort", () => {
     const body = chatCompletionBody(LLM_PROVIDER.OpenAI, request, false) as {
       dryRunMetadata?: unknown;

--- a/src/services/llm/chatCompletionBody.ts
+++ b/src/services/llm/chatCompletionBody.ts
@@ -21,7 +21,7 @@ export function chatCompletionBody(
 ) {
   const { dryRunMetadata, messages, ...rest } = req;
   void dryRunMetadata;
-  return {
+  const body = {
     ...rest,
     messages: messages.map((message) => ({
       ...message,
@@ -29,4 +29,14 @@ export function chatCompletionBody(
     })),
     stream,
   };
+
+  if (provider === LLM_PROVIDER.Local) {
+    return {
+      ...body,
+      reasoning_effort: "none",
+      reasoning: { effort: "none" },
+    };
+  }
+
+  return body;
 }

--- a/src/services/llm/index.ts
+++ b/src/services/llm/index.ts
@@ -2,6 +2,7 @@ import { useSettingsStore } from "#/stores";
 import { openrouterClient } from "./openrouter";
 import { cerebrasClient } from "./cerebras";
 import { openaiClient } from "./openai";
+import { localClient } from "./local";
 import { rayviseApiClient } from "./rayvise-api";
 import { dryRunClient } from "./dryRun";
 import type { LLMClient } from "./types";
@@ -24,6 +25,8 @@ export function getLLMClient(): LLMClient {
       return cerebrasClient;
     case LLM_PROVIDER.OpenAI:
       return openaiClient;
+    case LLM_PROVIDER.Local:
+      return localClient;
     case LLM_PROVIDER.OpenRouter:
     default:
       return openrouterClient;
@@ -35,18 +38,34 @@ export function getApiKey(): string {
     return "dry-run";
   }
 
-  const { provider, openrouterApiKey, cerebrasApiKey, openaiApiKey } =
-    useSettingsStore.getState();
+  const {
+    provider,
+    openrouterApiKey,
+    cerebrasApiKey,
+    openaiApiKey,
+    localApiKey,
+  } = useSettingsStore.getState();
 
   switch (provider) {
     case LLM_PROVIDER.Cerebras:
       return cerebrasApiKey;
     case LLM_PROVIDER.OpenAI:
       return openaiApiKey;
+    case LLM_PROVIDER.Local:
+      return localApiKey;
     case LLM_PROVIDER.OpenRouter:
     default:
       return openrouterApiKey;
   }
+}
+
+export function providerRequiresApiKey(): boolean {
+  if (DRY_RUN) {
+    return false;
+  }
+
+  const { provider } = useSettingsStore.getState();
+  return provider !== LLM_PROVIDER.Local;
 }
 
 export type { LLMClient, LLMRequest, LLMMessage } from "./types";

--- a/src/services/llm/local.test.ts
+++ b/src/services/llm/local.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsStore } from "#/stores";
+import { LLM_PROVIDER } from "./types";
+import { localClient } from "./local";
+
+const listeners = vi.hoisted(
+  () => new Map<string, (event: { payload: unknown }) => void>(),
+);
+const invoke = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(
+    (event: string, handler: (event: { payload: unknown }) => void) => {
+      listeners.set(event, handler);
+      return Promise.resolve(() => listeners.delete(event));
+    },
+  ),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke,
+}));
+
+describe("localClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listeners.clear();
+    useSettingsStore.setState({
+      provider: LLM_PROVIDER.Local,
+      localBaseUrl: "http://localhost:11434/v1",
+      localApiKey: "",
+      model: "llama3.2",
+    });
+  });
+
+  it("streams through Rust and strips think blocks across chunks", async () => {
+    invoke.mockImplementation(
+      (command: string, args: { sessionId: string }) => {
+        if (command === "stream_local_chat_completion") {
+          const handler = listeners.get("rayvise://local-llm-stream");
+          handler?.({
+            payload: { sessionId: args.sessionId, text: "Hello <thi" },
+          });
+          handler?.({
+            payload: {
+              sessionId: args.sessionId,
+              text: "nk>hidden</think> world",
+            },
+          });
+        }
+        return Promise.resolve();
+      },
+    );
+
+    let seen = "";
+    await localClient.stream(
+      {
+        model: "llama3.2",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      "",
+      (chunk) => {
+        seen += chunk;
+      },
+    );
+
+    expect(seen).toBe("Hello  world");
+    expect(invoke).toHaveBeenCalledWith(
+      "stream_local_chat_completion",
+      expect.objectContaining({
+        baseUrl: "http://localhost:11434/v1",
+        apiKey: "",
+      }),
+    );
+  });
+
+  it("cancels the Rust stream command on abort", async () => {
+    let rejectStream: (err: Error) => void = () => {};
+    invoke.mockImplementation((command: string) => {
+      if (command === "stream_local_chat_completion") {
+        return new Promise((_resolve, reject) => {
+          rejectStream = reject;
+        });
+      }
+      return Promise.resolve();
+    });
+
+    const controller = new AbortController();
+    const promise = localClient.stream(
+      {
+        model: "llama3.2",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      "",
+      () => {},
+      controller.signal,
+    );
+
+    await Promise.resolve();
+    controller.abort();
+    rejectStream(new Error("canceled"));
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(invoke).toHaveBeenCalledWith(
+      "cancel_local_chat_completion",
+      expect.objectContaining({ sessionId: expect.any(String) }),
+    );
+  });
+});

--- a/src/services/llm/local.ts
+++ b/src/services/llm/local.ts
@@ -1,0 +1,126 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useSettingsStore } from "#/stores";
+import { chatCompletionBody } from "./chatCompletionBody";
+import { createThinkBlockStripper } from "./streaming";
+import { LLM_PROVIDER, type LLMClient, type LLMRequest } from "./types";
+
+interface LocalStreamEvent {
+  sessionId: string;
+  text: string;
+}
+
+function abortError() {
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+function localSettings() {
+  const { localBaseUrl, localApiKey } = useSettingsStore.getState();
+  return { baseUrl: localBaseUrl, apiKey: localApiKey };
+}
+
+export async function listLocalModels(
+  baseUrl: string,
+  apiKey: string,
+): Promise<string[]> {
+  return await invoke<string[]>("list_local_models", {
+    baseUrl,
+    apiKey,
+  });
+}
+
+export const localClient: LLMClient = {
+  async complete(req: LLMRequest, _apiKey: string, signal?: AbortSignal) {
+    let text = "";
+    await this.stream(
+      req,
+      _apiKey,
+      (chunk) => {
+        text += chunk;
+      },
+      signal,
+    );
+
+    return {
+      text,
+      usage: {
+        input_tokens: null,
+        output_tokens: null,
+      },
+    };
+  },
+
+  async stream(
+    req: LLMRequest,
+    _apiKey: string,
+    onChunk: (text: string) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (signal?.aborted) {
+      throw abortError();
+    }
+
+    const sessionId = crypto.randomUUID();
+    const { baseUrl, apiKey } = localSettings();
+    const stripper = createThinkBlockStripper();
+    const unlisten = await listen<LocalStreamEvent>(
+      "rayvise://local-llm-stream",
+      (event) => {
+        if (event.payload.sessionId !== sessionId) {
+          return;
+        }
+
+        const text = stripper.push(event.payload.text);
+        if (text) {
+          onChunk(text);
+        }
+      },
+    );
+
+    const cancel = () => {
+      invoke("cancel_local_chat_completion", { sessionId }).catch(() => {});
+    };
+    let didAbort = false;
+    let rejectAbort: (err: DOMException) => void = () => {};
+    const abortPromise = new Promise<never>((_resolve, reject) => {
+      rejectAbort = reject;
+    });
+    const abortHandler = () => {
+      didAbort = true;
+      cancel();
+      rejectAbort(abortError());
+    };
+    signal?.addEventListener("abort", abortHandler, { once: true });
+
+    try {
+      const commandPromise = invoke("stream_local_chat_completion", {
+        sessionId,
+        baseUrl,
+        apiKey,
+        body: chatCompletionBody(LLM_PROVIDER.Local, req, true),
+      }).catch((err) => {
+        if (didAbort || signal?.aborted) {
+          return;
+        }
+
+        throw err;
+      });
+
+      await Promise.race([commandPromise, abortPromise]);
+
+      const remaining = stripper.flush();
+      if (remaining) {
+        onChunk(remaining);
+      }
+    } catch (err) {
+      if (signal?.aborted) {
+        throw abortError();
+      }
+
+      throw err;
+    } finally {
+      signal?.removeEventListener("abort", abortHandler);
+      unlisten();
+    }
+  },
+};

--- a/src/services/llm/models.test.ts
+++ b/src/services/llm/models.test.ts
@@ -42,6 +42,18 @@ describe("provider model registry", () => {
     ]);
   });
 
+  it("includes Local as a direct provider with a free-form default model", () => {
+    expect(getProviderModelOptions(LLM_PROVIDER.Local)).toEqual([
+      { value: "llama3.2", label: "llama3.2" },
+    ]);
+    expect(normalizeProviderModel(LLM_PROVIDER.Local, "custom:model")).toBe(
+      "custom:model",
+    );
+    expect(normalizeProviderModel(LLM_PROVIDER.Local, "   ")).toBe(
+      getDefaultModelForProvider(LLM_PROVIDER.Local),
+    );
+  });
+
   it("normalizes invalid provider-model combinations to the provider default", () => {
     expect(
       normalizeProviderModel(LLM_PROVIDER.OpenAI, "openai/gpt-oss-120b"),

--- a/src/services/llm/models.ts
+++ b/src/services/llm/models.ts
@@ -9,12 +9,14 @@ export const DIRECT_PROVIDER_OPTIONS = [
   LLM_PROVIDER.OpenRouter,
   LLM_PROVIDER.Cerebras,
   LLM_PROVIDER.OpenAI,
+  LLM_PROVIDER.Local,
 ] as const satisfies readonly LLMProvider[];
 
 const PROVIDER_LABELS: Record<LLMProvider, string> = {
   [LLM_PROVIDER.OpenRouter]: "OpenRouter",
   [LLM_PROVIDER.Cerebras]: "Cerebras",
   [LLM_PROVIDER.OpenAI]: "OpenAI",
+  [LLM_PROVIDER.Local]: "Local",
 };
 
 const PROVIDER_MODEL_OPTIONS: Record<LLMProvider, ProviderModelOption[]> = {
@@ -38,9 +40,12 @@ const PROVIDER_MODEL_OPTIONS: Record<LLMProvider, ProviderModelOption[]> = {
     { value: "gpt-5-nano", label: "GPT-5 Nano" },
     { value: "gpt-4o-mini", label: "GPT-4o Mini" },
   ],
+  [LLM_PROVIDER.Local]: [{ value: "llama3.2", label: "llama3.2" }],
 };
 
 export const DEFAULT_DIRECT_PROVIDER = LLM_PROVIDER.OpenRouter;
+export const DEFAULT_LOCAL_BASE_URL = "http://localhost:11434/v1";
+export const DEFAULT_LOCAL_MODEL = "llama3.2";
 
 export function isLLMProvider(value: unknown): value is LLMProvider {
   return (
@@ -78,6 +83,8 @@ export function getDefaultModelForProvider(provider: LLMProvider): string {
       return "openai/gpt-oss-120b";
     case LLM_PROVIDER.OpenAI:
       return "gpt-5-nano";
+    case LLM_PROVIDER.Local:
+      return DEFAULT_LOCAL_MODEL;
     default:
       return (PROVIDER_MODEL_OPTIONS[provider][0] as ProviderModelOption).value;
   }
@@ -87,6 +94,10 @@ export function isModelAllowedForProvider(
   provider: LLMProvider,
   model: string,
 ): boolean {
+  if (provider === LLM_PROVIDER.Local) {
+    return model.trim().length > 0;
+  }
+
   return PROVIDER_MODEL_OPTIONS[provider].some(
     (option) => option.value === model,
   );
@@ -96,6 +107,11 @@ export function normalizeProviderModel(
   provider: LLMProvider,
   model: unknown,
 ): string {
+  if (provider === LLM_PROVIDER.Local) {
+    const trimmed = typeof model === "string" ? model.trim() : "";
+    return trimmed || getDefaultModelForProvider(provider);
+  }
+
   return typeof model === "string" && isModelAllowedForProvider(provider, model)
     ? model
     : getDefaultModelForProvider(provider);
@@ -109,5 +125,7 @@ export function getProviderAccessDescription(provider: LLMProvider): string {
       return "Select from models currently validated against the Cerebras Inference API.";
     case LLM_PROVIDER.OpenAI:
       return "Select from supported OpenAI models.";
+    case LLM_PROVIDER.Local:
+      return "Use an Ollama-compatible local OpenAI endpoint. Model names can be selected from discovery or typed manually.";
   }
 }

--- a/src/services/llm/streaming.test.ts
+++ b/src/services/llm/streaming.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getCompletionText, parseSSEStream } from "./streaming";
+import {
+  createThinkBlockStripper,
+  getCompletionText,
+  parseSSEStream,
+} from "./streaming";
 
 function streamFromLines(lines: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -46,5 +50,13 @@ describe("streaming compatibility parsing", () => {
     );
 
     expect(seen).toBe("Hello world");
+  });
+
+  it("strips think blocks across chunk boundaries", () => {
+    const stripper = createThinkBlockStripper();
+
+    expect(stripper.push("Hello <thi")).toBe("Hello ");
+    expect(stripper.push("nk>hidden</think> world")).toBe(" world");
+    expect(stripper.flush()).toBe("");
   });
 });

--- a/src/services/llm/streaming.ts
+++ b/src/services/llm/streaming.ts
@@ -89,3 +89,73 @@ export async function parseSSEStream(
     }
   }
 }
+
+function longestSuffixPrefix(value: string, token: string): string {
+  const max = Math.min(value.length, token.length - 1);
+
+  for (let length = max; length > 0; length -= 1) {
+    const suffix = value.slice(-length).toLowerCase();
+    if (token.toLowerCase().startsWith(suffix)) {
+      return value.slice(-length);
+    }
+  }
+
+  return "";
+}
+
+function findTag(value: string, tag: string): number {
+  return value.toLowerCase().indexOf(tag.toLowerCase());
+}
+
+export function createThinkBlockStripper() {
+  const openTag = "<think>";
+  const closeTag = "</think>";
+  let buffer = "";
+  let insideThink = false;
+
+  return {
+    push(chunk: string): string {
+      buffer += chunk;
+      let output = "";
+
+      while (buffer) {
+        if (insideThink) {
+          const closeIndex = findTag(buffer, closeTag);
+          if (closeIndex === -1) {
+            buffer = longestSuffixPrefix(buffer, closeTag);
+            break;
+          }
+
+          buffer = buffer.slice(closeIndex + closeTag.length);
+          insideThink = false;
+          continue;
+        }
+
+        const openIndex = findTag(buffer, openTag);
+        if (openIndex === -1) {
+          const retained = longestSuffixPrefix(buffer, openTag);
+          output += buffer.slice(0, buffer.length - retained.length);
+          buffer = retained;
+          break;
+        }
+
+        output += buffer.slice(0, openIndex);
+        buffer = buffer.slice(openIndex + openTag.length);
+        insideThink = true;
+      }
+
+      return output;
+    },
+
+    flush(): string {
+      if (insideThink) {
+        buffer = "";
+        return "";
+      }
+
+      const output = buffer;
+      buffer = "";
+      return output;
+    },
+  };
+}

--- a/src/services/llm/types.ts
+++ b/src/services/llm/types.ts
@@ -2,6 +2,7 @@ export const LLM_PROVIDER = {
   OpenRouter: "openrouter",
   Cerebras: "cerebras",
   OpenAI: "openai",
+  Local: "local",
 } as const;
 
 export type LLMProvider = (typeof LLM_PROVIDER)[keyof typeof LLM_PROVIDER];

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_LOCAL_BASE_URL } from "#/services/llm/models";
+import { LLM_PROVIDER } from "#/services/llm/types";
+import { useSettingsStore } from "./settingsStore";
+
+function resetSettingsStore() {
+  useSettingsStore.setState({
+    mode: "direct",
+    provider: LLM_PROVIDER.OpenRouter,
+    openrouterApiKey: "",
+    cerebrasApiKey: "",
+    openaiApiKey: "",
+    localBaseUrl: DEFAULT_LOCAL_BASE_URL,
+    localApiKey: "",
+    localModelOptions: [],
+    modelSelections: {
+      [LLM_PROVIDER.OpenRouter]: "openai/gpt-oss-120b",
+      [LLM_PROVIDER.Cerebras]: "openai/gpt-oss-120b",
+      [LLM_PROVIDER.OpenAI]: "gpt-5-nano",
+      [LLM_PROVIDER.Local]: "llama3.2",
+    },
+    model: "openai/gpt-oss-120b",
+    reviewMode: false,
+    themeMode: "auto",
+  });
+}
+
+describe("settingsStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetSettingsStore();
+  });
+
+  it("remembers selected models per provider", () => {
+    useSettingsStore.getState().setProvider(LLM_PROVIDER.OpenAI);
+    useSettingsStore.getState().setModel("gpt-4o-mini");
+    useSettingsStore.getState().setProvider(LLM_PROVIDER.Local);
+    useSettingsStore.getState().setModel("custom:model");
+
+    useSettingsStore.getState().setProvider(LLM_PROVIDER.OpenAI);
+    expect(useSettingsStore.getState().model).toBe("gpt-4o-mini");
+
+    useSettingsStore.getState().setProvider(LLM_PROVIDER.Local);
+    expect(useSettingsStore.getState().model).toBe("custom:model");
+  });
+
+  it("migrates a legacy single model into the active provider selection", async () => {
+    localStorage.setItem(
+      "rayvise-settings",
+      JSON.stringify({
+        state: {
+          provider: LLM_PROVIDER.OpenAI,
+          model: "gpt-4o-mini",
+        },
+        version: 0,
+      }),
+    );
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().provider).toBe(LLM_PROVIDER.OpenAI);
+    expect(useSettingsStore.getState().model).toBe("gpt-4o-mini");
+    expect(
+      useSettingsStore.getState().modelSelections[LLM_PROVIDER.OpenAI],
+    ).toBe("gpt-4o-mini");
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -2,12 +2,67 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { LLMProvider } from "#/services/llm/types";
 import {
+  DEFAULT_LOCAL_BASE_URL,
   DEFAULT_DIRECT_PROVIDER,
+  getDefaultModelForProvider,
+  isLLMProvider,
   normalizeLLMProvider,
   normalizeProviderModel,
 } from "#/services/llm/models";
+import { LLM_PROVIDER } from "#/services/llm/types";
 
 export type ThemeMode = "light" | "dark" | "auto";
+export type ProviderModelSelections = Partial<Record<LLMProvider, string>>;
+
+function createDefaultModelSelections(): ProviderModelSelections {
+  return {
+    [LLM_PROVIDER.OpenRouter]: getDefaultModelForProvider(
+      LLM_PROVIDER.OpenRouter,
+    ),
+    [LLM_PROVIDER.Cerebras]: getDefaultModelForProvider(LLM_PROVIDER.Cerebras),
+    [LLM_PROVIDER.OpenAI]: getDefaultModelForProvider(LLM_PROVIDER.OpenAI),
+    [LLM_PROVIDER.Local]: getDefaultModelForProvider(LLM_PROVIDER.Local),
+  };
+}
+
+function normalizeModelSelections(
+  value: unknown,
+  legacyProvider: LLMProvider,
+  legacyModel: unknown,
+): ProviderModelSelections {
+  const defaults = createDefaultModelSelections();
+  const raw =
+    value && typeof value === "object"
+      ? (value as Partial<Record<string, unknown>>)
+      : {};
+
+  const selections: ProviderModelSelections = {};
+  for (const provider of Object.values(LLM_PROVIDER) as LLMProvider[]) {
+    selections[provider] = normalizeProviderModel(provider, raw[provider]);
+  }
+
+  selections[legacyProvider] = normalizeProviderModel(
+    legacyProvider,
+    legacyModel ?? raw[legacyProvider] ?? defaults[legacyProvider],
+  );
+
+  return selections;
+}
+
+function normalizeLocalModelOptions(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+}
 
 interface SettingsState {
   mode: "direct" | "api";
@@ -15,6 +70,10 @@ interface SettingsState {
   openrouterApiKey: string;
   cerebrasApiKey: string;
   openaiApiKey: string;
+  localBaseUrl: string;
+  localApiKey: string;
+  localModelOptions: string[];
+  modelSelections: ProviderModelSelections;
   model: string;
   reviewMode: boolean;
   themeMode: ThemeMode;
@@ -23,6 +82,9 @@ interface SettingsState {
   setOpenrouterApiKey: (key: string) => void;
   setCerebrasApiKey: (key: string) => void;
   setOpenaiApiKey: (key: string) => void;
+  setLocalBaseUrl: (baseUrl: string) => void;
+  setLocalApiKey: (key: string) => void;
+  setLocalModelOptions: (models: string[]) => void;
   setModel: (model: string) => void;
   setReviewMode: (reviewMode: boolean) => void;
   setThemeMode: (themeMode: ThemeMode) => void;
@@ -36,6 +98,10 @@ export const useSettingsStore = create<SettingsState>()(
       openrouterApiKey: "",
       cerebrasApiKey: "",
       openaiApiKey: "",
+      localBaseUrl: DEFAULT_LOCAL_BASE_URL,
+      localApiKey: "",
+      localModelOptions: [],
+      modelSelections: createDefaultModelSelections(),
       model: normalizeProviderModel(
         DEFAULT_DIRECT_PROVIDER,
         "openai/gpt-oss-120b",
@@ -46,14 +112,27 @@ export const useSettingsStore = create<SettingsState>()(
       setProvider: (provider) =>
         set((state) => ({
           provider,
-          model: normalizeProviderModel(provider, state.model),
+          model: normalizeProviderModel(
+            provider,
+            state.modelSelections[provider],
+          ),
         })),
       setOpenrouterApiKey: (openrouterApiKey) => set({ openrouterApiKey }),
       setCerebrasApiKey: (cerebrasApiKey) => set({ cerebrasApiKey }),
       setOpenaiApiKey: (openaiApiKey) => set({ openaiApiKey }),
+      setLocalBaseUrl: (localBaseUrl) => set({ localBaseUrl }),
+      setLocalApiKey: (localApiKey) => set({ localApiKey }),
+      setLocalModelOptions: (localModelOptions) =>
+        set({
+          localModelOptions: normalizeLocalModelOptions(localModelOptions),
+        }),
       setModel: (model) =>
         set((state) => ({
           model: normalizeProviderModel(state.provider, model),
+          modelSelections: {
+            ...state.modelSelections,
+            [state.provider]: normalizeProviderModel(state.provider, model),
+          },
         })),
       setReviewMode: (reviewMode) => set({ reviewMode }),
       setThemeMode: (themeMode) => set({ themeMode }),
@@ -63,14 +142,40 @@ export const useSettingsStore = create<SettingsState>()(
       merge: (persistedState, currentState) => {
         const persisted = (persistedState ?? {}) as Partial<SettingsState> & {
           reviewMode?: unknown;
+          provider?: unknown;
+          model?: unknown;
+          modelSelections?: unknown;
+          localBaseUrl?: unknown;
+          localApiKey?: unknown;
+          localModelOptions?: unknown;
         };
-        const provider = normalizeLLMProvider(persisted.provider);
+        const provider = isLLMProvider(persisted.provider)
+          ? persisted.provider
+          : normalizeLLMProvider(persisted.provider);
+        const modelSelections = normalizeModelSelections(
+          persisted.modelSelections,
+          provider,
+          persisted.model,
+        );
 
         return {
           ...currentState,
           ...persisted,
           provider,
-          model: normalizeProviderModel(provider, persisted.model),
+          localBaseUrl:
+            typeof persisted.localBaseUrl === "string" &&
+            persisted.localBaseUrl.trim()
+              ? persisted.localBaseUrl
+              : currentState.localBaseUrl,
+          localApiKey:
+            typeof persisted.localApiKey === "string"
+              ? persisted.localApiKey
+              : currentState.localApiKey,
+          localModelOptions: normalizeLocalModelOptions(
+            persisted.localModelOptions,
+          ),
+          modelSelections,
+          model: normalizeProviderModel(provider, modelSelections[provider]),
           reviewMode:
             typeof persisted.reviewMode === "boolean"
               ? persisted.reviewMode


### PR DESCRIPTION
## Background

This PR introduces robust support for local, privacy-preserving LLM interactions via a new `Local` provider, designed to connect to self-hosted endpoints like Ollama. It updates core services, the settings mechanism, and user-facing documentation (`README.md`, `docs/DEV_GETTING_STARTED.md`, and `docs/LOCAL_LLM.md`) to support this capability while maintaining strict security boundaries (loopback-only enforcement).

## Changes

**Local LLM Support Implementation**
*   Implemented `Local` as a new LLM provider type and registered it in UI components and services.
*   Created `src-tauri/src/commands/local_llm.rs` and related service files to handle all local LLM communication through Tauri backend commands.
*   The local client logic in `src/services/llm/local.ts` now manages the `AbortSignal` for stream cancellation and emits events for UI updates.
*   Added robust model and connection validation in the local command, strictly enforcing loopback-only addresses and handling path normalization to `/v1/`.
*   Updated `chatCompletionBody` in request serialization to include mandatory reasoning suppression fields (`reasoning_effort: "none"`) when using the `Local` provider.

**Settings & UI Updates**
*   Updated `SettingsPage.tsx` to include dedicated sections for local configuration (Base URL, API Key, Local Model Refresh button) when the `Local` provider is selected.
*   Updated `settingsStore.ts` and related selectors to handle and persist `localBaseUrl`, `localApiKey`, and `localModelOptions`.
*   Enhanced model selection in `SettingsPage.tsx` to account for manually managed local models alongside whitelisted cloud models.

**Documentation & Type Updates**
*   Created comprehensive documentation in `docs/LOCAL_LLM.md` detailing setup for Ollama, connection protocols, security boundaries (loopback enforcement), and hardware considerations (unified memory).
*   Updated `README.md` and `docs/DEV_GETTING_STARTED.md` to direct users to the new local LLM documentation and explain its operation alongside cloud providers.
*   Updated LLM type definitions to formally include `LLM_PROVIDER.Local`.

**Code Quality & Refactoring**
*   Improved `src-tauri/src/commands/apps.rs` copy logic to be safer.
*   Refactored LLM services to properly manage state and provider context checks (e.g., `useAICompletionListener.test.tsx` now verifies key existence checks for API key requirement).

## Testing
*   Verified the local client successfully initiates, streams, and gracefully handles cancellation via Tauri commands.
*   Tested local endpoint validation, ensuring only loopback IPs and correct paths (`/v1/`) are accepted.
*   Confirmed that the local endpoint requests correctly inject reasoning suppression parameters into the request body.
*   Updated state store tests to ensure local URLs and keys persist correctly in state management.
*   Validated UI flow in `SettingsPage.tsx` by adding a manual model refresh mechanism that calls the local model discovery API.