### PR TITLE
chore: add provider and model info to dry run

### DIFF
--- a/src/lib/core/instantMode.test.ts
+++ b/src/lib/core/instantMode.test.ts
@@ -70,6 +70,13 @@ describe("runInstantMode", () => {
 
     expect(hoisted.showProgressOverlay).toHaveBeenCalled();
     expect(hoisted.stream).toHaveBeenCalled();
+    expect(hoisted.stream.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        dryRunMetadata: expect.objectContaining({
+          provider: "openrouter",
+        }),
+      }),
+    );
     expect(hoisted.invoke).toHaveBeenCalledWith("write_text_back", {
       text: "done",
       targetPid: 99,

--- a/src/lib/core/instantMode.ts
+++ b/src/lib/core/instantMode.ts
@@ -46,6 +46,7 @@ export async function runInstantMode(p: ModeParams) {
         dryRunMetadata: {
           promptName: p.prompt.name,
           pageUrl: p.pageUrl,
+          provider: p.provider,
         },
       },
       p.apiKey,

--- a/src/lib/core/reviewMode.test.ts
+++ b/src/lib/core/reviewMode.test.ts
@@ -5,6 +5,7 @@ const hoisted = vi.hoisted(() => {
   const emit = vi.fn().mockResolvedValue(undefined);
   const saveCompletion = vi.fn().mockResolvedValue(undefined);
   const showReviewOverlay = vi.fn();
+  const showToastOverlay = vi.fn();
   const stream = vi.fn(
     async (
       _req: unknown,
@@ -16,7 +17,7 @@ const hoisted = vi.hoisted(() => {
       onChunk("out");
     },
   );
-  return { emit, saveCompletion, showReviewOverlay, stream };
+  return { emit, saveCompletion, showReviewOverlay, showToastOverlay, stream };
 });
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -25,6 +26,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 vi.mock("#/services/overlayWindows", () => ({
   showReviewOverlay: hoisted.showReviewOverlay,
+  showToastOverlay: hoisted.showToastOverlay,
   REVIEW_STORAGE_KEY: "rayvise-pending-review",
 }));
 
@@ -84,5 +86,49 @@ describe("runReviewMode", () => {
       "rayvise://completion-saved",
       "rayvise://stream-done",
     ]);
+    expect(hoisted.showToastOverlay).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast and saves errored completion when review streaming fails", async () => {
+    hoisted.stream.mockRejectedValueOnce(
+      new Error(
+        "Local provider request failed: error sending request for url (http://localhost:11434/v1/chat/completions)",
+      ),
+    );
+
+    const controller = new AbortController();
+    await runReviewMode({
+      signal: controller.signal,
+      selected_text: "in",
+      target_pid: 42,
+      app: "com.app",
+      prompt: { id: "p1", name: "N", text: "sys" },
+      promptSource: "default",
+      pageUrl: null,
+      matchedWebsitePattern: null,
+      model: "m",
+      provider: "local",
+      completionId: "cid-err",
+      t0: 1_700_000_000_000,
+      apiKey: "",
+    });
+
+    expect(hoisted.showToastOverlay).toHaveBeenCalledWith(
+      "Could not connect to Ollama. Start Ollama and try again.",
+      "error",
+      4500,
+    );
+    expect(hoisted.emit).toHaveBeenCalledWith("rayvise://stream-error", {
+      message:
+        "Local provider request failed: error sending request for url (http://localhost:11434/v1/chat/completions)",
+    });
+    expect(hoisted.saveCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "cid-err",
+        hadError: 1,
+        errorMessage:
+          "Local provider request failed: error sending request for url (http://localhost:11434/v1/chat/completions)",
+      }),
+    );
   });
 });

--- a/src/lib/core/reviewMode.test.ts
+++ b/src/lib/core/reviewMode.test.ts
@@ -62,6 +62,13 @@ describe("runReviewMode", () => {
 
     expect(hoisted.showReviewOverlay).toHaveBeenCalled();
     expect(hoisted.stream).toHaveBeenCalled();
+    expect(hoisted.stream.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        dryRunMetadata: expect.objectContaining({
+          provider: "openrouter",
+        }),
+      }),
+    );
     expect(hoisted.saveCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "cid-1",

--- a/src/lib/core/reviewMode.ts
+++ b/src/lib/core/reviewMode.ts
@@ -2,10 +2,28 @@ import { emit } from "@tauri-apps/api/event";
 import { getLLMClient } from "#/services/llm";
 import {
   showReviewOverlay,
+  showToastOverlay,
   REVIEW_STORAGE_KEY,
 } from "#/services/overlayWindows";
 import { saveCompletion } from "#/services/db";
 import { ModeParams, isAbortError } from "./types";
+import { LLMProvider } from "#/services/llm/types";
+
+function toReviewErrorToastMessage(
+  errorMessage: string,
+  provider: string,
+): string {
+  if (
+    provider === "local" &&
+    /(Local provider request failed|Could not connect to Local provider)/i.test(
+      errorMessage,
+    )
+  ) {
+    return "Could not connect to Ollama. Start Ollama and try again.";
+  }
+
+  return `Error: ${errorMessage}`;
+}
 
 // Review mode is used when the user wants to review the completion before applying it to the target app.
 export async function runReviewMode(p: ModeParams) {
@@ -34,7 +52,7 @@ export async function runReviewMode(p: ModeParams) {
         dryRunMetadata: {
           promptName: p.prompt.name,
           pageUrl: p.pageUrl,
-          provider: p.provider,
+          provider: p.provider as LLMProvider,
         },
       },
       p.apiKey,
@@ -106,6 +124,11 @@ export async function runReviewMode(p: ModeParams) {
     }
 
     const errorMessage = err instanceof Error ? err.message : String(err);
+    showToastOverlay(
+      toReviewErrorToastMessage(errorMessage, p.provider),
+      "error",
+      4500,
+    );
     await emit("rayvise://stream-error", { message: errorMessage });
     localStorage.removeItem(REVIEW_STORAGE_KEY);
 

--- a/src/lib/core/reviewMode.ts
+++ b/src/lib/core/reviewMode.ts
@@ -34,6 +34,7 @@ export async function runReviewMode(p: ModeParams) {
         dryRunMetadata: {
           promptName: p.prompt.name,
           pageUrl: p.pageUrl,
+          provider: p.provider,
         },
       },
       p.apiKey,

--- a/src/services/llm/dryRun.test.ts
+++ b/src/services/llm/dryRun.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { dryRunClient } from "./dryRun";
+
+describe("dryRunClient", () => {
+  it("includes provider and model info in the dry-run header", async () => {
+    const chunks: string[] = [];
+
+    await dryRunClient.stream(
+      {
+        messages: [
+          { role: "instruction", content: "sys" },
+          { role: "user", content: "selected text" },
+        ],
+        model: "gpt-4o-mini",
+        dryRunMetadata: {
+          promptName: "Prompt A",
+          pageUrl: "https://example.com/page",
+          provider: "openai",
+        },
+      },
+      "dry-run",
+      (chunk) => {
+        chunks.push(chunk);
+      },
+    );
+
+    expect(chunks).toEqual([
+      "[DRY RUN] | Provider: OpenAI | Model: gpt-4o-mini | Prompt: Prompt A | Page: https://example.com/page\n\nselected text",
+    ]);
+  });
+
+  it("falls back to the raw user text when metadata is missing", async () => {
+    const chunks: string[] = [];
+
+    const result = await dryRunClient.complete(
+      {
+        messages: [{ role: "user", content: "plain text" }],
+        model: "m",
+      },
+      "dry-run",
+    );
+
+    chunks.push(result.text);
+
+    expect(chunks).toEqual(["[DRY RUN] | Model: m\n\nplain text"]);
+  });
+});

--- a/src/services/llm/dryRun.ts
+++ b/src/services/llm/dryRun.ts
@@ -1,3 +1,4 @@
+import { getProviderLabel } from "./models";
 import type { LLMClient, LLMRequest } from "./types";
 
 export const dryRunClient: LLMClient = {
@@ -26,6 +27,13 @@ function getDryRunText(req: LLMRequest) {
     [...req.messages].reverse().find((m) => m.role === "user")?.content ?? "";
   const metadata = req.dryRunMetadata;
   const parts: string[] = ["[DRY RUN]"];
+  if (metadata?.provider) {
+    parts.push(`Provider: ${getProviderLabel(metadata.provider)}`);
+  }
+  const model = req.model.trim();
+  if (model) {
+    parts.push(`Model: ${model}`);
+  }
   const name = metadata?.promptName?.trim();
   if (name) {
     parts.push(`Prompt: ${name}`);

--- a/src/services/llm/types.ts
+++ b/src/services/llm/types.ts
@@ -16,6 +16,7 @@ export interface LLMMessage {
 export interface LLMDryRunMetadata {
   promptName: string;
   pageUrl?: string | null;
+  provider?: LLMProvider;
 }
 
 export interface LLMRequest {


### PR DESCRIPTION
## Background

This PR improves dry-run output metadata and strengthens review-mode error handling. It also adds coverage to ensure dry-run headers include provider/model information.

## Changes

- **Dry-run metadata**
  - Extended `dryRunMetadata` to include `provider` in `instantMode` and `reviewMode`.
  - Updated `LLMDryRunMetadata` to optionally carry `provider`.
  - Enhanced dry-run text generation to include provider label and model in the `[DRY RUN]` header.

- **Review-mode error UX**
  - Added `showToastOverlay` support in `reviewMode`.
  - Implemented provider-aware toast messaging for local-provider connectivity failures (e.g., Ollama).
  - On streaming failure: show error toast, emit `rayvise://stream-error`, and persist the errored completion.

- **Tests**
  - Updated instant/review mode tests to assert `dryRunMetadata.provider` is passed to the stream request.
  - Added a new review mode test verifying toast + errored completion behavior when streaming fails.
  - Added unit tests for `dryRunClient` header formatting (with provider/model info and fallback when metadata is missing).

## Testing

### Manually tested dry run contains provider + model info
<img width="600" height="700" alt="Screenshot 2026-05-10 at 7 15 27 PM" src="https://github.com/user-attachments/assets/be9b0198-1f94-44e3-9cb6-021b7e01e82c" />

### Tested local with ollama not running and saw error toast displayed properly

- Ran/verified unit tests for:
  - `runInstantMode` dry-run metadata includes provider.
  - `runReviewMode` dry-run metadata includes provider and error path shows toast + saves completion.
  - `dryRunClient` header formatting and fallback behavior.