### PR TITLE
feat: history page performance improvements and use app icons

### DIFF
--- a/src/lib/core/instantMode.ts
+++ b/src/lib/core/instantMode.ts
@@ -7,6 +7,7 @@ import {
   showToastOverlay,
 } from "#/services/overlayWindows";
 import { saveCompletion } from "#/services/db";
+import type { LLMProvider } from "#/services/llm/types";
 import { ModeParams, isAbortError } from "./types";
 
 // Instant mode is used when the user wants to apply the completion to the target app immediately.
@@ -46,7 +47,7 @@ export async function runInstantMode(p: ModeParams) {
         dryRunMetadata: {
           promptName: p.prompt.name,
           pageUrl: p.pageUrl,
-          provider: p.provider,
+          provider: p.provider as LLMProvider,
         },
       },
       p.apiKey,

--- a/src/pages/history/DetailDialog.tsx
+++ b/src/pages/history/DetailDialog.tsx
@@ -535,33 +535,43 @@ export function DetailDialog({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="bg-card text-card-foreground ring-border flex max-h-[90vh] w-full max-w-5xl flex-col ring-1 sm:max-w-5xl">
+      <DialogContent
+        className={cn(
+          "bg-card text-card-foreground ring-border flex max-h-[90vh] w-full max-w-5xl flex-col ring-1 sm:max-w-5xl",
+          /* Avoid vertical jump when body height changes: default dialog is translate-y-centered. */
+          "top-[max(1.5rem,min(7vh,3rem))] translate-y-0",
+        )}
+      >
         <DialogHeader>
           <DialogTitle className="text-foreground text-sm font-semibold">
             Details
           </DialogTitle>
         </DialogHeader>
-        {detailStatus === "loading" && (
-          <div className="text-muted-foreground flex min-h-[min(440px,58vh)] flex-1 items-center justify-center text-[13px]">
-            Loading…
-          </div>
-        )}
-        {detailStatus === "not_found" && (
-          <div className="text-muted-foreground flex min-h-[min(440px,58vh)] flex-1 items-center justify-center text-[13px]">
-            This entry could not be loaded.
-          </div>
-        )}
-        {detailStatus === "ready" && detailRow && (
-          <DetailDialogBody
-            key={detailRow.id}
-            row={detailRow}
-            appName={appName}
-            appIconSrc={appIconSrc}
-            onClose={onClose}
-            onNavigateToPrompt={onNavigateToPrompt}
-            onNavigateToWebsiteSite={onNavigateToWebsiteSite}
-          />
-        )}
+        <div className="flex min-h-[min(560px,calc(58vh+9rem))] flex-1 flex-col overflow-hidden">
+          {detailStatus === "loading" && (
+            <div className="text-muted-foreground flex flex-1 items-center justify-center text-[13px]">
+              Loading…
+            </div>
+          )}
+          {detailStatus === "not_found" && (
+            <div className="text-muted-foreground flex flex-1 items-center justify-center text-[13px]">
+              This entry could not be loaded.
+            </div>
+          )}
+          {detailStatus === "ready" && detailRow && (
+            <div className="flex min-h-0 flex-1 flex-col">
+              <DetailDialogBody
+                key={detailRow.id}
+                row={detailRow}
+                appName={appName}
+                appIconSrc={appIconSrc}
+                onClose={onClose}
+                onNavigateToPrompt={onNavigateToPrompt}
+                onNavigateToWebsiteSite={onNavigateToWebsiteSite}
+              />
+            </div>
+          )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/pages/history/DetailDialog.tsx
+++ b/src/pages/history/DetailDialog.tsx
@@ -32,7 +32,9 @@ import {
 } from "./helpers";
 
 interface DetailDialogProps {
-  row: CompletionEntry | null;
+  selectedId: string | null;
+  detailStatus: "idle" | "loading" | "ready" | "not_found";
+  detailRow: CompletionEntry | null;
   onClose: () => void;
   appName: (id: string) => string;
   appIconSrc: (id: string) => string | undefined;
@@ -520,25 +522,39 @@ function DetailDialogBody({
 }
 
 export function DetailDialog({
-  row,
+  selectedId,
+  detailStatus,
+  detailRow,
   onClose,
   appName,
   appIconSrc,
   onNavigateToPrompt,
   onNavigateToWebsiteSite,
 }: DetailDialogProps) {
+  const open = selectedId !== null;
+
   return (
-    <Dialog open={row !== null} onOpenChange={(open) => !open && onClose()}>
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="bg-card text-card-foreground ring-border flex max-h-[90vh] w-full max-w-5xl flex-col ring-1 sm:max-w-5xl">
         <DialogHeader>
           <DialogTitle className="text-foreground text-sm font-semibold">
             Details
           </DialogTitle>
         </DialogHeader>
-        {row && (
+        {detailStatus === "loading" && (
+          <div className="text-muted-foreground flex min-h-[min(440px,58vh)] flex-1 items-center justify-center text-[13px]">
+            Loading…
+          </div>
+        )}
+        {detailStatus === "not_found" && (
+          <div className="text-muted-foreground flex min-h-[min(440px,58vh)] flex-1 items-center justify-center text-[13px]">
+            This entry could not be loaded.
+          </div>
+        )}
+        {detailStatus === "ready" && detailRow && (
           <DetailDialogBody
-            key={row.id}
-            row={row}
+            key={detailRow.id}
+            row={detailRow}
             appName={appName}
             appIconSrc={appIconSrc}
             onClose={onClose}

--- a/src/pages/history/DetailDialog.tsx
+++ b/src/pages/history/DetailDialog.tsx
@@ -35,6 +35,7 @@ interface DetailDialogProps {
   row: CompletionEntry | null;
   onClose: () => void;
   appName: (id: string) => string;
+  appIconSrc: (id: string) => string | undefined;
   onNavigateToPrompt?: (promptId: string) => void;
   onNavigateToWebsiteSite?: (siteId: string) => void;
 }
@@ -167,6 +168,7 @@ function ResizableTwoColumn({
 interface DetailDialogBodyProps {
   row: CompletionEntry;
   appName: (id: string) => string;
+  appIconSrc: (id: string) => string | undefined;
   onClose: () => void;
   onNavigateToPrompt?: (promptId: string) => void;
   onNavigateToWebsiteSite?: (siteId: string) => void;
@@ -175,11 +177,13 @@ interface DetailDialogBodyProps {
 function DetailDialogMetadataHeader({
   row,
   appName,
+  appIconSrc,
   onClose,
   onNavigateToPrompt,
   onNavigateToWebsiteSite,
 }: DetailDialogBodyProps) {
   const { prompts, websitePromptSites } = usePromptsStore();
+  const appIcon = appIconSrc(row.appId);
   const promptSourceLabel = promptSourceDisplayLabel(row.promptSource);
   const promptExists = prompts.some((p) => p.id === row.promptId);
   const websiteSiteId = useMemo(
@@ -211,7 +215,16 @@ function DetailDialogMetadataHeader({
   return (
     <div className="border-border bg-muted/15 shrink-0 rounded-lg border px-3 py-2.5">
       <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
-        <span>{appName(row.appId)}</span>
+        <span className="text-foreground inline-flex items-center gap-1.5">
+          {appIcon ? (
+            <img
+              src={appIcon}
+              alt=""
+              className="h-4 w-4 shrink-0 object-contain"
+            />
+          ) : null}
+          <span>{appName(row.appId)}</span>
+        </span>
         <span>·</span>
         <span className="text-foreground inline-flex items-center gap-0.5">
           <span>{row.promptName}</span>
@@ -304,6 +317,7 @@ function DetailDialogMetadataHeader({
 function DetailDialogBody({
   row,
   appName,
+  appIconSrc,
   onClose,
   onNavigateToPrompt,
   onNavigateToWebsiteSite,
@@ -400,6 +414,7 @@ function DetailDialogBody({
       <DetailDialogMetadataHeader
         row={row}
         appName={appName}
+        appIconSrc={appIconSrc}
         onClose={onClose}
         onNavigateToPrompt={onNavigateToPrompt}
         onNavigateToWebsiteSite={onNavigateToWebsiteSite}
@@ -508,6 +523,7 @@ export function DetailDialog({
   row,
   onClose,
   appName,
+  appIconSrc,
   onNavigateToPrompt,
   onNavigateToWebsiteSite,
 }: DetailDialogProps) {
@@ -524,6 +540,7 @@ export function DetailDialog({
             key={row.id}
             row={row}
             appName={appName}
+            appIconSrc={appIconSrc}
             onClose={onClose}
             onNavigateToPrompt={onNavigateToPrompt}
             onNavigateToWebsiteSite={onNavigateToWebsiteSite}

--- a/src/pages/history/EntryCard.tsx
+++ b/src/pages/history/EntryCard.tsx
@@ -1,24 +1,24 @@
-import type { KeyboardEvent } from "react";
+import { memo, type KeyboardEvent } from "react";
 import { XCircle } from "lucide-react";
-import type { CompletionEntry } from "#/services/db";
+import type { CompletionListEntry } from "#/services/db";
 import { Button, buttonVariants } from "#/components/ui/button";
 import { cn } from "#/lib/utils";
 import { timeAgo, appColor, promptSourceDisplayLabel } from "./helpers";
 import { StatusIcon } from "./StatusIcon";
 
 interface EntryCardProps {
-  row: CompletionEntry;
+  row: CompletionListEntry;
   appName: (id: string) => string;
   appIconSrc: (id: string) => string | undefined;
-  onClick: () => void;
-  onDelete: () => void;
+  onOpenDetail: (id: string) => void;
+  onDelete: (id: string) => void;
 }
 
-export function EntryCard({
+function EntryCardInner({
   row,
   appName,
   appIconSrc,
-  onClick,
+  onOpenDetail,
   onDelete,
 }: EntryCardProps) {
   const name = appName(row.appId);
@@ -29,7 +29,7 @@ export function EntryCard({
   function handleRowKeyDown(e: KeyboardEvent) {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      onClick();
+      onOpenDetail(row.id);
     }
   }
 
@@ -37,7 +37,7 @@ export function EntryCard({
     <div
       role="button"
       tabIndex={0}
-      onClick={onClick}
+      onClick={() => onOpenDetail(row.id)}
       onKeyDown={handleRowKeyDown}
       className={cn(
         buttonVariants({ variant: "ghost" }),
@@ -117,7 +117,7 @@ export function EntryCard({
           size="icon-xs"
           onClick={(e) => {
             e.stopPropagation();
-            onDelete();
+            onDelete(row.id);
           }}
           className="text-muted-foreground/60 hover:text-red-400"
         >
@@ -127,3 +127,5 @@ export function EntryCard({
     </div>
   );
 }
+
+export const EntryCard = memo(EntryCardInner);

--- a/src/pages/history/EntryCard.tsx
+++ b/src/pages/history/EntryCard.tsx
@@ -9,13 +9,21 @@ import { StatusIcon } from "./StatusIcon";
 interface EntryCardProps {
   row: CompletionEntry;
   appName: (id: string) => string;
+  appIconSrc: (id: string) => string | undefined;
   onClick: () => void;
   onDelete: () => void;
 }
 
-export function EntryCard({ row, appName, onClick, onDelete }: EntryCardProps) {
+export function EntryCard({
+  row,
+  appName,
+  appIconSrc,
+  onClick,
+  onDelete,
+}: EntryCardProps) {
   const name = appName(row.appId);
   const initial = name.charAt(0).toUpperCase();
+  const iconSrc = appIconSrc(row.appId);
   const promptSourceLabel = promptSourceDisplayLabel(row.promptSource);
 
   function handleRowKeyDown(e: KeyboardEvent) {
@@ -39,12 +47,20 @@ export function EntryCard({ row, appName, onClick, onDelete }: EntryCardProps) {
       {/* App + time */}
       <div className="mb-1 flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2">
-          <span
-            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-white"
-            style={{ backgroundColor: appColor(row.appId) }}
-          >
-            {initial}
-          </span>
+          {iconSrc ? (
+            <img
+              src={iconSrc}
+              alt=""
+              className="h-5 w-5 shrink-0 object-contain"
+            />
+          ) : (
+            <span
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-white"
+              style={{ backgroundColor: appColor(row.appId) }}
+            >
+              {initial}
+            </span>
+          )}
           <span className="text-muted-foreground truncate text-[11px]">
             {name}
           </span>

--- a/src/pages/history/HistoryPage.test.tsx
+++ b/src/pages/history/HistoryPage.test.tsx
@@ -1,7 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { HistoryPage } from "./HistoryPage";
 import { useAppsStore } from "#/stores";
+import type { CompletionEntry, CompletionListEntry } from "#/services/db";
+
+vi.mock("#/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="resizable-panel-group" className={className}>
+      {children}
+    </div>
+  ),
+  ResizablePanel: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="resizable-panel" className={className}>
+      {children}
+    </div>
+  ),
+  ResizableHandle: () => <div data-testid="resizable-handle" />,
+}));
 
 vi.mock("#/hooks/useAppIcons", () => ({
   useAppIcons: () => ({}),
@@ -9,6 +38,7 @@ vi.mock("#/hooks/useAppIcons", () => ({
 
 const dbMocks = vi.hoisted(() => ({
   listCompletions: vi.fn(),
+  getCompletion: vi.fn(),
   getUsageStats: vi.fn(),
   listDistinctPrompts: vi.fn(),
   deleteCompletion: vi.fn().mockResolvedValue(undefined),
@@ -18,6 +48,7 @@ const dbMocks = vi.hoisted(() => ({
 
 vi.mock("#/services/db", () => ({
   listCompletions: (...args: unknown[]) => dbMocks.listCompletions(...args),
+  getCompletion: (...args: unknown[]) => dbMocks.getCompletion(...args),
   getUsageStats: (...args: unknown[]) => dbMocks.getUsageStats(...args),
   listDistinctPrompts: (...args: unknown[]) =>
     dbMocks.listDistinctPrompts(...args),
@@ -38,12 +69,10 @@ vi.mock("@tauri-apps/api/event", () => ({
   },
 }));
 
-const sampleRow = {
+const sampleListRow: CompletionListEntry = {
   id: "c1",
   timestamp: Date.now(),
   inputText: "hello",
-  outputText: "world",
-  finalText: null,
   wasApplied: 0,
   isReviewMode: 1,
   hadError: 0,
@@ -54,12 +83,18 @@ const sampleRow = {
   appId: "com.app",
   promptId: "p1",
   promptName: "P",
-  promptText: "t",
   promptSource: "default",
   pageUrl: null,
   matchedWebsitePattern: null,
   model: "m",
   provider: "openrouter",
+};
+
+const sampleFullRow: CompletionEntry = {
+  ...sampleListRow,
+  outputText: "world",
+  finalText: null,
+  promptText: "full prompt body",
 };
 
 describe("HistoryPage", () => {
@@ -71,7 +106,8 @@ describe("HistoryPage", () => {
       activeApp: null,
       hiddenAppBundleIds: [],
     });
-    dbMocks.listCompletions.mockResolvedValue([sampleRow]);
+    dbMocks.listCompletions.mockResolvedValue([sampleListRow]);
+    dbMocks.getCompletion.mockResolvedValue(sampleFullRow);
     dbMocks.getUsageStats.mockResolvedValue({
       id: "global",
       totalCompletions: 1,
@@ -101,5 +137,53 @@ describe("HistoryPage", () => {
     await waitFor(() =>
       expect(dbMocks.listCompletions).toHaveBeenCalledTimes(2),
     );
+  });
+
+  it("loads full completion when opening the detail dialog", async () => {
+    let resolveDetail!: (row: CompletionEntry | null) => void;
+    const detailPromise = new Promise<CompletionEntry | null>((resolve) => {
+      resolveDetail = resolve;
+    });
+    dbMocks.getCompletion.mockReturnValue(detailPromise);
+
+    const user = userEvent.setup();
+    render(<HistoryPage />);
+
+    await waitFor(() =>
+      expect(dbMocks.listCompletions).toHaveBeenCalledTimes(1),
+    );
+
+    const card = screen.getByText("hello").closest('[role="button"]');
+    expect(card).toBeTruthy();
+    await user.click(card!);
+
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(dbMocks.getCompletion).toHaveBeenCalledWith("c1"),
+    );
+    resolveDetail(sampleFullRow);
+
+    await waitFor(() => {
+      expect(screen.getByText("world")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a message when getCompletion returns null", async () => {
+    dbMocks.getCompletion.mockResolvedValue(null);
+    const user = userEvent.setup();
+    render(<HistoryPage />);
+
+    await waitFor(() =>
+      expect(dbMocks.listCompletions).toHaveBeenCalledTimes(1),
+    );
+
+    const card = screen.getByText("hello").closest('[role="button"]');
+    await user.click(card!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("This entry could not be loaded."),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/history/HistoryPage.test.tsx
+++ b/src/pages/history/HistoryPage.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 import { HistoryPage } from "./HistoryPage";
+import { useAppsStore } from "#/stores";
+
+vi.mock("#/hooks/useAppIcons", () => ({
+  useAppIcons: () => ({}),
+}));
 
 const dbMocks = vi.hoisted(() => ({
   listCompletions: vi.fn(),
@@ -61,6 +66,11 @@ describe("HistoryPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listeners.clear();
+    useAppsStore.setState({
+      apps: [],
+      activeApp: null,
+      hiddenAppBundleIds: [],
+    });
     dbMocks.listCompletions.mockResolvedValue([sampleRow]);
     dbMocks.getUsageStats.mockResolvedValue({
       id: "global",

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+  useReducer,
+} from "react";
 import { listen } from "@tauri-apps/api/event";
 import { Search, Trash2 } from "lucide-react";
 import { useAppsStore } from "#/stores";
@@ -7,10 +14,12 @@ import {
   listCompletions,
   listDistinctPrompts,
   getUsageStats,
+  getCompletion,
   deleteCompletion,
   clearAllCompletions,
   resetAllHistory,
   type CompletionEntry,
+  type CompletionListEntry,
 } from "#/services/db";
 import {
   AlertDialog,
@@ -30,6 +39,48 @@ import { useAppIcons } from "#/hooks/useAppIcons";
 
 const LIST_LIMIT = 200;
 
+type DetailFetchStatus = "idle" | "loading" | "ready" | "not_found";
+
+interface DetailState {
+  id: string | null;
+  row: CompletionEntry | null;
+  status: DetailFetchStatus;
+}
+
+type DetailAction =
+  | { type: "open"; id: string }
+  | { type: "close" }
+  | {
+      type: "resolve";
+      requestId: string;
+      row: CompletionEntry | null;
+    };
+
+const initialDetail: DetailState = {
+  id: null,
+  row: null,
+  status: "idle",
+};
+
+function detailReducer(state: DetailState, action: DetailAction): DetailState {
+  switch (action.type) {
+    case "open":
+      return { id: action.id, row: null, status: "loading" };
+    case "close":
+      return initialDetail;
+    case "resolve":
+      if (state.id !== action.requestId) {
+        return state;
+      }
+      if (action.row) {
+        return { ...state, row: action.row, status: "ready" };
+      }
+      return { ...state, row: null, status: "not_found" };
+    default:
+      return state;
+  }
+}
+
 interface HistoryPageProps {
   onNavigateToPrompt?: (promptId: string) => void;
   onNavigateToWebsiteSite?: (siteId: string) => void;
@@ -39,7 +90,7 @@ export function HistoryPage({
   onNavigateToPrompt,
   onNavigateToWebsiteSite,
 }: HistoryPageProps = {}) {
-  const [rows, setRows] = useState<CompletionEntry[]>([]);
+  const [rows, setRows] = useState<CompletionListEntry[]>([]);
   const [stats, setStats] = useState<Awaited<
     ReturnType<typeof getUsageStats>
   > | null>(null);
@@ -47,16 +98,34 @@ export function HistoryPage({
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
-  const [detailRow, setDetailRow] = useState<CompletionEntry | null>(null);
+  const [detail, dispatchDetail] = useReducer(detailReducer, initialDetail);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const { apps } = useAppsStore();
-  const iconSrcByBundleId = useAppIcons(apps);
+  const detailIdForStaleDeleteRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    detailIdForStaleDeleteRef.current = detail.id;
+  }, [detail.id]);
+
+  const appsForHistoryIcons = useMemo(() => {
+    const ids = new Set(rows.map((r) => r.appId));
+    return apps.filter((a) => ids.has(a.bundleId));
+  }, [rows, apps]);
+
+  const iconSrcByBundleId = useAppIcons(appsForHistoryIcons);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const appNameByBundleId = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const a of apps) {
+      m.set(a.bundleId, a.name);
+    }
+    return m;
+  }, [apps]);
+
   const appName = useCallback(
-    (bundleId: string) =>
-      apps.find((a) => a.bundleId === bundleId)?.name ?? bundleId,
-    [apps],
+    (bundleId: string) => appNameByBundleId.get(bundleId) ?? bundleId,
+    [appNameByBundleId],
   );
   const appIconSrc = useCallback(
     (bundleId: string) => iconSrcByBundleId[bundleId],
@@ -81,6 +150,34 @@ export function HistoryPage({
       .catch(() => {});
   }, [refreshKey, debouncedSearch]);
 
+  // Load full completion when a row is selected (async updates only)
+  useEffect(() => {
+    if (!detail.id) {
+      return;
+    }
+
+    const requestId = detail.id;
+    let cancelled = false;
+
+    getCompletion(requestId)
+      .then((row) => {
+        if (cancelled) {
+          return;
+        }
+        dispatchDetail({ type: "resolve", requestId, row });
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        dispatchDetail({ type: "resolve", requestId, row: null });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detail.id]);
+
   // Refresh when a new completion is saved
   const doRefresh = useCallback(() => setRefreshKey((k) => k + 1), []);
   useEffect(() => {
@@ -89,6 +186,18 @@ export function HistoryPage({
       unlisten.then((fn) => fn());
     };
   }, [doRefresh]);
+
+  const closeDetail = useCallback(() => {
+    dispatchDetail({ type: "close" });
+  }, []);
+
+  const openDetail = useCallback((id: string) => {
+    dispatchDetail({ type: "open", id });
+  }, []);
+
+  const requestDelete = useCallback((id: string) => {
+    setDeletingId(id);
+  }, []);
 
   const handleSearchChange = (val: string) => {
     setSearch(val);
@@ -103,6 +212,9 @@ export function HistoryPage({
       deleteCompletion(id)
         .then(() => {
           setDeletingId(null);
+          if (detailIdForStaleDeleteRef.current === id) {
+            dispatchDetail({ type: "close" });
+          }
           setRefreshKey((k) => k + 1);
         })
         .catch(() => {});
@@ -113,7 +225,10 @@ export function HistoryPage({
 
   const handleClearHistory = () => {
     clearAllCompletions()
-      .then(() => setRefreshKey((k) => k + 1))
+      .then(() => {
+        closeDetail();
+        setRefreshKey((k) => k + 1);
+      })
       .catch(() => {});
   };
 
@@ -122,6 +237,7 @@ export function HistoryPage({
       .then(() => {
         setSearch("");
         setDebouncedSearch("");
+        closeDetail();
         setRefreshKey((k) => k + 1);
       })
       .catch(() => {});
@@ -167,8 +283,8 @@ export function HistoryPage({
                 row={row}
                 appName={appName}
                 appIconSrc={appIconSrc}
-                onClick={() => setDetailRow(row)}
-                onDelete={() => setDeletingId(row.id)}
+                onOpenDetail={openDetail}
+                onDelete={requestDelete}
               />
             ))}
           </div>
@@ -193,8 +309,10 @@ export function HistoryPage({
 
       {/* Detail dialog */}
       <DetailDialog
-        row={detailRow}
-        onClose={() => setDetailRow(null)}
+        selectedId={detail.id}
+        detailStatus={detail.status}
+        detailRow={detail.row}
+        onClose={closeDetail}
         appName={appName}
         appIconSrc={appIconSrc}
         onNavigateToPrompt={onNavigateToPrompt}

--- a/src/pages/history/HistoryPage.tsx
+++ b/src/pages/history/HistoryPage.tsx
@@ -26,6 +26,7 @@ import {
 import { EntryCard } from "#/pages/history/EntryCard";
 import { DetailDialog } from "#/pages/history/DetailDialog";
 import { OverviewPanel } from "#/pages/history/OverviewPanel";
+import { useAppIcons } from "#/hooks/useAppIcons";
 
 const LIST_LIMIT = 200;
 
@@ -49,12 +50,17 @@ export function HistoryPage({
   const [detailRow, setDetailRow] = useState<CompletionEntry | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const { apps } = useAppsStore();
+  const iconSrcByBundleId = useAppIcons(apps);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const appName = useCallback(
     (bundleId: string) =>
       apps.find((a) => a.bundleId === bundleId)?.name ?? bundleId,
     [apps],
+  );
+  const appIconSrc = useCallback(
+    (bundleId: string) => iconSrcByBundleId[bundleId],
+    [iconSrcByBundleId],
   );
 
   // Fetch data whenever refreshKey or debouncedSearch changes
@@ -160,6 +166,7 @@ export function HistoryPage({
                 key={row.id}
                 row={row}
                 appName={appName}
+                appIconSrc={appIconSrc}
                 onClick={() => setDetailRow(row)}
                 onDelete={() => setDeletingId(row.id)}
               />
@@ -189,6 +196,7 @@ export function HistoryPage({
         row={detailRow}
         onClose={() => setDetailRow(null)}
         appName={appName}
+        appIconSrc={appIconSrc}
         onNavigateToPrompt={onNavigateToPrompt}
         onNavigateToWebsiteSite={onNavigateToWebsiteSite}
       />

--- a/src/pages/history/StatusIcon.tsx
+++ b/src/pages/history/StatusIcon.tsx
@@ -1,8 +1,8 @@
 import { CheckCircle2, XCircle, AlertCircle } from "lucide-react";
-import type { CompletionEntry } from "#/services/db";
+import type { CompletionListEntry } from "#/services/db";
 
 // Status Icon display for history page
-export function StatusIcon({ row }: { row: CompletionEntry }) {
+export function StatusIcon({ row }: { row: Pick<CompletionListEntry, "hadError" | "wasApplied"> }) {
   if (row.hadError) {
     return <AlertCircle size={13} className="shrink-0 text-red-500" />;
   }

--- a/src/pages/settings/ExportDialog.tsx
+++ b/src/pages/settings/ExportDialog.tsx
@@ -57,7 +57,8 @@ function IndeterminateCheckbox({
 const columns: ColumnDef<PromptSearchRow>[] = [
   {
     id: "select",
-    size: 36,
+    // Room for px-2 + 16px checkbox without overflowing into "Name"
+    size: 44,
     header: ({ table }) => (
       <IndeterminateCheckbox
         checked={table.getIsAllRowsSelected()}
@@ -218,15 +219,27 @@ export function ExportDialog({ open, onOpenChange }: ExportDialogProps) {
 
             {/* Table */}
             <div className="flex-1 overflow-auto">
-              <table className="w-full text-sm">
-                <thead className="bg-muted/40 sticky top-0">
+              <table className="w-full table-fixed border-separate border-spacing-0 text-sm">
+                <thead className="bg-muted sticky top-0 z-10 shadow-[0_1px_0_0_var(--border)]">
                   {table.getHeaderGroups().map((hg) => (
                     <tr key={hg.id}>
                       {hg.headers.map((header) => (
                         <th
                           key={header.id}
-                          className="text-muted-foreground px-3 py-2 text-left text-xs font-medium"
-                          style={{ width: header.column.columnDef.size }}
+                          className={cn(
+                            "text-muted-foreground py-2 text-xs font-medium",
+                            header.column.id === "select"
+                              ? "w-11 px-2 text-center align-middle"
+                              : "px-3 text-left align-middle",
+                          )}
+                          style={
+                            header.column.columnDef.size != null
+                              ? {
+                                  width: header.column.columnDef.size,
+                                  minWidth: header.column.columnDef.size,
+                                }
+                              : undefined
+                          }
                         >
                           {flexRender(
                             header.column.columnDef.header,
@@ -260,7 +273,12 @@ export function ExportDialog({ open, onOpenChange }: ExportDialogProps) {
                         {row.getVisibleCells().map((cell) => (
                           <td
                             key={cell.id}
-                            className="px-3 py-2"
+                            className={cn(
+                              "py-2 align-middle",
+                              cell.column.id === "select"
+                                ? "w-11 px-2 text-center"
+                                : "px-3",
+                            )}
                             onClick={
                               // Prevent double-toggle when clicking the checkbox itself
                               cell.column.id === "select"

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -1,9 +1,20 @@
 import Database from "@tauri-apps/plugin-sql";
 import { drizzle } from "drizzle-orm/sqlite-proxy";
-import { eq, desc, like, or } from "drizzle-orm";
+import { eq, desc, like, or, sql } from "drizzle-orm";
 import { completions, usageStats } from "./schema";
 
 export type CompletionEntry = typeof completions.$inferSelect;
+
+/** Max characters of `input_text` loaded for history list rows (full text in detail). */
+export const HISTORY_LIST_INPUT_PREVIEW_CHARS = 800;
+
+/** History list row: excludes large columns; `inputText` is a DB-side preview only. */
+export type CompletionListEntry = Omit<
+  CompletionEntry,
+  "outputText" | "finalText" | "promptText" | "inputText"
+> & {
+  inputText: string;
+};
 
 export type UsageStatsRow = Omit<
   typeof usageStats.$inferSelect,
@@ -173,16 +184,37 @@ export async function updateCompletionOutcome(
   }
 }
 
+const completionListSelect = {
+  id: completions.id,
+  timestamp: completions.timestamp,
+  inputText: sql<string>`substr(${completions.inputText}, 1, ${HISTORY_LIST_INPUT_PREVIEW_CHARS})`,
+  wasApplied: completions.wasApplied,
+  isReviewMode: completions.isReviewMode,
+  hadError: completions.hadError,
+  errorMessage: completions.errorMessage,
+  inputTokens: completions.inputTokens,
+  outputTokens: completions.outputTokens,
+  completionMs: completions.completionMs,
+  appId: completions.appId,
+  promptId: completions.promptId,
+  promptName: completions.promptName,
+  promptSource: completions.promptSource,
+  pageUrl: completions.pageUrl,
+  matchedWebsitePattern: completions.matchedWebsitePattern,
+  model: completions.model,
+  provider: completions.provider,
+} as const;
+
 export async function listCompletions(
   limit: number,
   offset: number,
   search?: string,
-): Promise<CompletionEntry[]> {
+): Promise<CompletionListEntry[]> {
   const db = await getDb();
   if (search) {
     const pattern = `%${search}%`;
     const rows = await db
-      .select()
+      .select(completionListSelect)
       .from(completions)
       .where(
         or(
@@ -196,15 +228,28 @@ export async function listCompletions(
       .orderBy(desc(completions.timestamp))
       .limit(limit)
       .offset(offset);
-    return rows as CompletionEntry[];
+    return rows as CompletionListEntry[];
   }
   const rows = await db
-    .select()
+    .select(completionListSelect)
     .from(completions)
     .orderBy(desc(completions.timestamp))
     .limit(limit)
     .offset(offset);
-  return rows as CompletionEntry[];
+  return rows as CompletionListEntry[];
+}
+
+export async function getCompletion(
+  id: string,
+): Promise<CompletionEntry | null> {
+  const db = await getDb();
+  const rows = await db
+    .select()
+    .from(completions)
+    .where(eq(completions.id, id))
+    .limit(1);
+  const row = rows[0];
+  return row ? (row as CompletionEntry) : null;
 }
 
 export async function listDistinctPrompts(): Promise<


### PR DESCRIPTION
## Background

This PR improves history page performance and UX by loading full completion details only when needed, while also adding app icons in the history UI and tightening a few related layouts and typings.

## Changes

- Split history data access into list rows and full detail rows:
  - Added `CompletionListEntry` and a `getCompletion(id)` lookup.
  - Limited history list queries to a preview of `inputText` instead of loading full completion payloads.
- Reworked history detail loading:
  - History detail dialog now opens by selected entry ID and shows loading/not-found states.
  - Full completion data is fetched asynchronously when a history item is opened.
  - Detail dialog closes automatically after deleting the currently viewed entry or clearing history/resetting data.
- Improved history item rendering:
  - Added app icons to history cards and detail header, with fallback to the existing colored initial badge.
  - Memoized entry cards and updated click/delete handlers to work by row ID.
  - Adjusted status icon typing to accept the smaller list-row shape.
- Updated detail dialog presentation:
  - Added icon support in the metadata header.
  - Adjusted dialog positioning and body sizing to reduce vertical jump when content changes.
- Refined export dialog table layout:
  - Increased checkbox column width and switched the table to a fixed/separated layout for better alignment.
  - Updated sticky header styling and cell spacing.
- Added/updated tests:
  - Covered async detail loading and the not-found state in history page tests.
  - Mocked supporting layout hooks/components used by the updated page.

## Testing

### App icons in history page
<img width="655" height="593" alt="Screenshot 2026-05-14 at 3 27 33 PM" src="https://github.com/user-attachments/assets/86e46cb5-a44b-4f91-9c93-e0e247af9b7c" />


- Added Vitest coverage for:
  - Loading full completion details on row open.
  - Rendering the not-found state when a completion cannot be loaded.
- Existing history page list/refresh behavior remains covered by the updated test suite.