### PR TITLE
style: small sidebar and apps page UI improvements

### DIFF
--- a/src/components/Sidebar/PromptsSection.tsx
+++ b/src/components/Sidebar/PromptsSection.tsx
@@ -155,7 +155,7 @@ export function PromptsSection({
           ) : null}
         </span>
         {isDefault && (
-          <Star className="fill-primary text-primary mr-1.5 h-2.5 w-2.5 shrink-0" />
+          <Star className="fill-primary text-primary mr-1 h-2.5 w-2.5 shrink-0" />
         )}
       </Button>
     );
@@ -165,7 +165,7 @@ export function PromptsSection({
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       {prompts.length > 0 ? (
         <div className="shrink-0">
-          <p className="text-muted-foreground mb-1 px-3 text-xs font-semibold tracking-wider uppercase select-none">
+          <p className="text-muted-foreground mb-1 px-3 text-xs tracking-wider select-none">
             Prompts
           </p>
           <div className="mb-2 px-2">
@@ -221,7 +221,7 @@ export function PromptsSection({
                     open={isOpen}
                     onOpenChange={() => toggleGroup(app.bundleId)}
                   >
-                    <CollapsibleTrigger className="text-foreground/80 hover:bg-secondary hover:text-foreground flex w-full cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors select-none">
+                    <CollapsibleTrigger className="text-foreground/80 hover:bg-secondary hover:text-foreground flex w-full cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-[13px] leading-snug font-medium transition-colors select-none">
                       {iconSrcByBundleId[app.bundleId] ? (
                         <img
                           src={iconSrcByBundleId[app.bundleId]}
@@ -260,7 +260,7 @@ export function PromptsSection({
                   open={resolvedOpenGroups.has("__unassigned__")}
                   onOpenChange={() => toggleGroup("__unassigned__")}
                 >
-                  <CollapsibleTrigger className="text-foreground/80 hover:bg-secondary hover:text-foreground flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors select-none">
+                  <CollapsibleTrigger className="text-foreground/80 hover:bg-secondary hover:text-foreground flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-[13px] leading-snug font-medium transition-colors select-none">
                     <ChevronRight
                       className={cn(
                         "h-3.5 w-3.5 shrink-0 transition-transform duration-150",

--- a/src/pages/apps/AppsPage.tsx
+++ b/src/pages/apps/AppsPage.tsx
@@ -108,7 +108,7 @@ export function AppsPage({ onNavigateToSettings }: AppsPageProps) {
                 <div
                   key={app.bundleId}
                   className={cn(
-                    "border-border/70 bg-card/40 hover:border-border hover:bg-card/60 rounded-xl border px-3 py-2.5 transition-colors",
+                    "border-border/70 bg-card/40 hover:border-border hover:bg-card/60 rounded-xl border px-3 py-2 transition-colors",
                     assigned.length > 0 && "shadow-xs",
                   )}
                 >
@@ -150,7 +150,7 @@ export function AppsPage({ onNavigateToSettings }: AppsPageProps) {
                     </DropdownMenu>
                   </div>
 
-                  <div className="bg-muted/20 mt-3 rounded-xl border border-dashed border-white/10 p-3">
+                  <div className="bg-muted/20 mt-1 rounded-xl border border-dashed border-white/10 p-3">
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <p className="text-foreground/90 text-xs font-medium tracking-wide uppercase">
                         Mapped prompts
@@ -190,7 +190,7 @@ export function AppsPage({ onNavigateToSettings }: AppsPageProps) {
                         ))}
                       </div>
                     ) : (
-                      <p className="text-muted-foreground mt-3 text-xs font-light italic">
+                      <p className="text-muted-foreground mt-2 text-xs font-light italic">
                         No prompts assigned yet. Add one below for quick access
                         when this app is active.
                       </p>


### PR DESCRIPTION
## Background

This PR makes small visual refinements to the sidebar prompts section and apps page to tighten spacing and improve typography consistency.

## Changes

- Adjusted spacing for the default prompt star icon in the sidebar.
- Removed extra emphasis from the "Prompts" section header by simplifying its text styling.
- Updated collapsible app/group headers in the prompts sidebar to use slightly smaller, medium-weight text with tighter line height.
- Reduced vertical padding in app cards on the Apps page for a denser layout.
- Tightened spacing above the mapped prompts panel and its empty-state message on the Apps page.

## Testing

### Manual visual checks
<img width="259" height="665" alt="Screenshot 2026-05-14 at 5 16 12 PM" src="https://github.com/user-attachments/assets/3d24787a-2423-446c-99e5-5312476fbb25" />
<img width="1197" height="482" alt="Screenshot 2026-05-14 at 5 16 35 PM" src="https://github.com/user-attachments/assets/ce8cc63e-0e04-41ca-a185-d013439ab13d" />
